### PR TITLE
feat(integrity): file integrity scan + mail/Slack/Discord summary notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 All notable changes to `ozankurt/laravel-shield` will be documented in this file.
 
-## [1.0.0-beta.1] — 2026-05-26
+## [1.0.0-beta.1], 2026-05-26
 
-This is the first beta of the Wordfence-parity upgrade. **Breaking changes throughout** — there is no upgrade path from 0.x (`ozankurt/laravel-security`); fresh install required.
+This is the first beta of the Wordfence-parity upgrade. **Breaking changes throughout**, there is no upgrade path from 0.x (`ozankurt/laravel-security`); fresh install required.
 
 ### Breaking changes
 - **Package renamed** from `ozankurt/laravel-security` → `ozankurt/laravel-shield`
 - **PHP namespace** renamed from `OzanKurt\Security` → `OzanKurt\Shield`
 - **Config file** renamed from `config/security.php` → `config/shield.php`
-- **All tables** dropped and recreated under `ls_*` prefix (no migration of old data — fresh install)
+- **All tables** dropped and recreated under `ls_*` prefix (no migration of old data, fresh install)
 - **Dashboard routes** moved from `/security/*` to `/shield/*`
 - **Artisan commands** renamed from `security:*` to `shield:*`
 - **Translation namespace** changed from `security::` to `shield::`
@@ -20,8 +20,8 @@ This is the first beta of the Wordfence-parity upgrade. **Breaking changes throu
 - **Gate name** changed from `viewSecurityDashboard` to `viewShieldDashboard`
 
 ### New features
-- **Full ACL system** (`ls_acl`) replacing the old `security_ips` — supports ip, cidr, asn, country, region, city, hostname, ua_regex, ref_regex matchers (asn/geo/hostname are stubs returning false in beta.1, full implementation lands in 1.1)
-- **DB-backed WAF rules** (`ls_waf_rules`) — 47 builtin patterns extracted from old config arrays, manageable via admin panel (UI in beta.2)
+- **Full ACL system** (`ls_acl`) replacing the old `security_ips`, supports ip, cidr, asn, country, region, city, hostname, ua_regex, ref_regex matchers (asn/geo/hostname are stubs returning false in beta.1, full implementation lands in 1.1)
+- **DB-backed WAF rules** (`ls_waf_rules`), 47 builtin patterns extracted from old config arrays, manageable via admin panel (UI in beta.2)
 - **Tamper-evident audit log** (`ls_audit_log`) with HMAC-SHA256 chain (each record stores prev_hash + hmac)
 - **Three-layer bypass mechanism** preventing admin lockout:
   - Header bypass key (`LS_BYPASS_KEY` env + `X-Security-Bypass` header)
@@ -29,7 +29,7 @@ This is the first beta of the Wordfence-parity upgrade. **Breaking changes throu
   - Recovery Artisan commands (`shield:bypass-add`, `shield:bypass-remove`, `shield:bypass-list`)
 - **`shield:install`** one-command setup (publishes, migrates, generates secrets, seeds, optional self-IP whitelist)
 - **Cache management dashboard** (Laravel Debugbar-inspired) at `/shield/cache`
-- **CorrelationId middleware** — per-request UUID7 propagated to all events (distributed-trace-style)
+- **CorrelationId middleware**, per-request UUID7 propagated to all events (distributed-trace-style)
 - **11 lookup tables** replacing all PHP enums (cached forever, sub-ms name→id resolution)
 
 ### Internal patterns

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/ozankurt/laravel-shield.svg?style=flat-square)](https://packagist.org/packages/ozankurt/laravel-shield)
 [![License](https://img.shields.io/packagist/l/ozankurt/laravel-shield.svg?style=flat-square)](LICENSE.md)
 
-**Comprehensive security suite for Laravel — the Wordfence equivalent.**
+**Comprehensive security suite for Laravel, the Wordfence equivalent.**
 
 WAF + scanner + ACL + audit log + live traffic + notifications, all configurable, all auditable, all Laravel-native.
 
-> **Brand site:** [laravel-shield.ozankurt.com](https://laravel-shield.ozankurt.com) — docs, pricing, license activation.
+> **Brand site:** [laravel-shield.ozankurt.com](https://laravel-shield.ozankurt.com), docs, pricing, license activation.
 
 ---
 
@@ -16,7 +16,7 @@ WAF + scanner + ACL + audit log + live traffic + notifications, all configurable
 | Need | What Shield gives you |
 |---|---|
 | Block malicious requests | 15+ WAF middlewares (XSS, SQLi, LFI, RFI, PHP wrappers, sessions, agents, geo, bots, keyword path filters) + DB-backed rule engine |
-| Manage allow/deny lists | Unified `ls_acl` table — IP / CIDR / ASN / country / regex / hostname, first-match-wins evaluation, Redis-cached |
+| Manage allow/deny lists | Unified `ls_acl` table, IP / CIDR / ASN / country / regex / hostname, first-match-wins evaluation, Redis-cached |
 | Detect malware | Scanner with native engine + ClamAV + composer audit; quarantine + restore; signature feed sync |
 | Audit-log everything | HMAC-chained `ls_audit_log`, file/config/composer drift detection, `HasAuditLog` trait for model events |
 | See live traffic | Sampled `ls_live_traffic` table with optional real-time broadcasting (Reverb / Pusher / Ably) |
@@ -107,13 +107,13 @@ Premium unlocks:
 - Hosted audit-log sink (forward audit events to the Shield Central app for cross-site aggregation)
 - Future SIEM dashboard integration
 
-The license check is honest soft-enforcement (see [docs/premium.md](docs/premium.md) — the real moat is the API services Ozan hosts, which patching the local check can't unlock).
+The license check is honest soft-enforcement (see [docs/premium.md](docs/premium.md), the real moat is the API services Ozan hosts, which patching the local check can't unlock).
 
 ## Companion packages
 
-- **`ozankurt/laravel-shield-filament`** — Filament panel adapter. v1.x for Filament 3 + 4, v2.x for Filament 5+. (Ships post-1.0.)
-- **`ozankurt/laravel-shield-signatures`** — Public GitHub repo of malware signatures. `shield:signatures-sync` pulls from here.
+- **`ozankurt/laravel-shield-filament`**, Filament panel adapter. v1.x for Filament 3 + 4, v2.x for Filament 5+. (Ships post-1.0.)
+- **`ozankurt/laravel-shield-signatures`**, Public GitHub repo of malware signatures. `shield:signatures-sync` pulls from here.
 
 ## License
 
-MIT — see [LICENSE.md](LICENSE.md).
+MIT, see [LICENSE.md](LICENSE.md).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,11 +2,11 @@
 
 ## From 0.x to 1.0.0-beta.1
 
-This is a **breaking** release — all tables, config keys, and namespaces change. There is no automated migration; perform a fresh install.
+This is a **breaking** release, all tables, config keys, and namespaces change. There is no automated migration; perform a fresh install.
 
 ### Steps
 
-1. **Update composer.json** — change requirement from `ozankurt/laravel-security` to `ozankurt/laravel-shield`. The new package's `replace` clause handles the conflict:
+1. **Update composer.json**, change requirement from `ozankurt/laravel-security` to `ozankurt/laravel-shield`. The new package's `replace` clause handles the conflict:
 
    ```bash
    composer require ozankurt/laravel-shield:^1.0.0-beta

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,8 @@
     "ozankurt/agent": "^1.0",
     "ramsey/uuid": "^4.7",
     "voku/anti-xss": "~4.1.42",
-    "voku/portable-utf8": "^6.0.13"
+    "voku/portable-utf8": "^6.0.13",
+    "laravel/slack-notification-channel": "^3.8"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.5|^10.0",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "ozankurt/laravel-shield",
-  "description": "Comprehensive Laravel security suite — WAF, malware scanner, ACL, audit log, live traffic, and notifications. The Wordfence-equivalent for Laravel.",
+  "description": "Comprehensive Laravel security suite, WAF, malware scanner, ACL, audit log, live traffic, and notifications. The Wordfence-equivalent for Laravel.",
   "keywords": [
     "laravel",
     "shield",

--- a/config/shield.php
+++ b/config/shield.php
@@ -688,6 +688,11 @@ return [
             'changes_days' => 30,
         ],
 
+        'heartbeat' => [
+            'enabled' => env('LS_INTEGRITY_HEARTBEAT_ENABLED', true),
+            'max_age_hours' => env('LS_INTEGRITY_HEARTBEAT_MAX_AGE_HOURS', 26),
+        ],
+
         // Ordered, first match wins. {public_docroot} expands to the resolved public root.
         'severity_rules' => [
             ['when' => ['path_any' => ['public/**', 'storage/app/public/**', '{public_docroot}/**'], 'ext_any' => ['php', 'phtml', 'phar', 'phps', 'inc', 'pht']], 'severity' => 'critical', 'non_suppressible' => true],

--- a/config/shield.php
+++ b/config/shield.php
@@ -105,6 +105,14 @@ return [
                 'discord',
             ],
         ],
+
+        'integrity_changed' => [
+            'enabled' => env('FIREWALL_NOTIFICATIONS_INTEGRITY_CHANGED_ENABLED', false),
+            'channels' => [
+                'mail',
+                'discord',
+            ],
+        ],
     ],
 
     'notification_channels' => [
@@ -624,6 +632,71 @@ return [
             'enabled' => env('LS_WATCH_ENABLED', false),
             'paths' => [],
             'poll_interval_ms' => env('LS_WATCH_POLL_MS', 3000),
+        ],
+    ],
+
+    'integrity' => [
+        'enabled' => env('LS_INTEGRITY_ENABLED', false),
+
+        'disks' => [
+            'app' => [
+                'roots' => [base_path()],
+                'include' => ['**/*'],
+                'exclude' => [
+                    'vendor/**', 'node_modules/**', '.git/**',
+                    'storage/framework/**', 'storage/logs/**', 'bootstrap/cache/**',
+                    'storage/shield/**', // the baseline artifact lives here
+                ],
+                'follow_symlinks' => false,
+                'max_file_size' => 50 * 1024 * 1024, // size-only above this, EXCEPT script extensions
+            ],
+        ],
+
+        'hash_algo' => 'sha256',
+        'queue' => env('LS_INTEGRITY_QUEUE', 'shield-integrity'),
+
+        'schedule' => [
+            'enabled' => env('LS_INTEGRITY_SCHEDULE_ENABLED', false),
+            'cron' => env('LS_INTEGRITY_SCAN_CRON', '0 * * * *'),
+        ],
+
+        'baseline' => [
+            'auto_bless_on_first_run' => false,
+            'sign_artifact' => true,
+            // A key FILE outside the scan root is preferred; falls back to the env value.
+            'hmac_key_path' => env('LS_INTEGRITY_HMAC_KEY_PATH'),
+            'hmac_key' => env('LS_INTEGRITY_HMAC_KEY'),
+        ],
+
+        'limits' => [
+            'max_files' => 500000,
+            'max_iterations' => 1000000,
+            'max_runtime' => 3600,
+            'max_persisted_changes_per_run' => 5000,
+        ],
+
+        'notify' => [
+            'suppress_when_no_changes' => true,
+            'send_all_clear' => false,
+            'max_paths_per_group' => 15,
+            'timezone' => 'UTC',
+            'disclose_paths_to_external_channels' => false,
+        ],
+
+        'retention' => [
+            'runs_days' => 90,
+            'changes_days' => 30,
+        ],
+
+        // Ordered, first match wins. {public_docroot} expands to the resolved public root.
+        'severity_rules' => [
+            ['when' => ['path_any' => ['public/**', 'storage/app/public/**', '{public_docroot}/**'], 'ext_any' => ['php', 'phtml', 'phar', 'phps', 'inc', 'pht']], 'severity' => 'critical', 'non_suppressible' => true],
+            ['when' => ['change_type_any' => ['deleted']], 'severity' => 'high'],
+            ['when' => ['path_any' => ['app/**', 'routes/**', 'config/**'], 'ext_any' => ['php']], 'severity' => 'high'],
+            ['when' => ['path_any' => ['vendor/**']], 'severity' => 'high'],
+            ['when' => ['path_any' => ['.env', '.env.*', '**/.htaccess', '**/.user.ini']], 'severity' => 'medium'],
+            ['when' => ['change_type_any' => ['became_unreadable']], 'severity' => 'medium'],
+            ['when' => ['always' => true], 'severity' => 'low'],
         ],
     ],
 

--- a/config/shield.php
+++ b/config/shield.php
@@ -110,6 +110,7 @@ return [
             'enabled' => env('FIREWALL_NOTIFICATIONS_INTEGRITY_CHANGED_ENABLED', false),
             'channels' => [
                 'mail',
+                'slack',
                 'discord',
             ],
         ],
@@ -680,7 +681,10 @@ return [
             'send_all_clear' => false,
             'max_paths_per_group' => 15,
             'timezone' => 'UTC',
-            'disclose_paths_to_external_channels' => false,
+            // Whether the changed file paths are listed in Slack/Discord payloads
+            // (which traverse third-party webhooks). Default on to match the card;
+            // set false to redact paths from external channels and link to the dashboard instead.
+            'disclose_paths_to_external_channels' => true,
         ],
 
         'retention' => [

--- a/config/shield.php
+++ b/config/shield.php
@@ -11,7 +11,7 @@ return [
     |
     | LS_BYPASS_KEY is intentionally read via env() inside the middleware (not
     | here) so it is never baked into the config cache. Add IPs here (or via
-    | LS_BYPASS_IPS) to whitelist them permanently — they cannot be removed via
+    | LS_BYPASS_IPS) to whitelist them permanently, they cannot be removed via
     | the dashboard UI.
     |
     */
@@ -741,12 +741,12 @@ return [
          * the hit + auto-blocks the source IP for shield.honeypot.block_duration
          * seconds.
          *
-         * Wildcard subpaths are matched automatically — adding "wp-admin" also
+         * Wildcard subpaths are matched automatically, adding "wp-admin" also
          * catches /wp-admin, /wp-admin/, /wp-admin/install.php, etc.
          *
          * Paths below are high-confidence probes that have ZERO legitimate use
          * in a Laravel app. Do NOT add /api, /robots.txt, /favicon.ico,
-         * /.well-known/*, /sitemap.xml, /health, /up — those are legitimate.
+         * /.well-known/*, /sitemap.xml, /health, /up, those are legitimate.
          */
         'paths' => [
             // WordPress core probes
@@ -979,7 +979,7 @@ return [
             'channel' => env('LS_LIVE_TRAFFIC_CHANNEL', 'shield.live-traffic'),
 
             // Whether realtime broadcasting requires a premium license.
-            // True (default) for new installs — matches the published
+            // True (default) for new installs, matches the published
             // feature gating. False preserves v1.x behavior where any
             // install with real_time.enabled=true got broadcasts.
             // Set false on upgrade if you self-host Reverb and don't
@@ -1027,7 +1027,7 @@ return [
     | Shield::isFeatureAvailable($feature) so the free fallback applies
     | when the license is missing, expired, or revoked.
     |
-    | The license key is treated as a secret — it is NEVER logged into
+    | The license key is treated as a secret, it is NEVER logged into
     | ls_audit_log, NEVER appears in telemetry, and NEVER shows up in
     | rendered dashboard pages in clear text.
     |
@@ -1035,7 +1035,7 @@ return [
     'premium' => [
         'license_key' => env('LS_PREMIUM_LICENSE_KEY'),
 
-        // Optional rotation secret for HMAC signing — separate from the
+        // Optional rotation secret for HMAC signing, separate from the
         // license key so operators can rotate signing material on incident
         // response without revoking the whole license. When unset, the
         // license key is used as the HMAC secret.
@@ -1086,11 +1086,11 @@ return [
 
         // Connectivity-test echo endpoint. Used by shield:central-test +
         // the License dashboard's "Test connectivity" button. Falls back
-        // to {heartbeat_host}/api/test/ping when unset — only override
+        // to {heartbeat_host}/api/test/ping when unset, only override
         // when running a non-standard Central deployment.
         'test_ping_url' => env('LS_PREMIUM_TEST_PING_URL'),
 
-        // Heartbeat — once per configured interval, plugin pings Central
+        // Heartbeat, once per configured interval, plugin pings Central
         // with summary stats (request count, block count, version) so the
         // Central dashboard can show "last seen" for each protected site.
         'heartbeat' => [

--- a/database/migrations/2026_05_26_000001_drop_legacy_security_tables.php
+++ b/database/migrations/2026_05_26_000001_drop_legacy_security_tables.php
@@ -21,6 +21,6 @@ return new class extends Migration
 
     public function down(): void
     {
-        // No reverse — these tables are obsolete in v1.0
+        // No reverse, these tables are obsolete in v1.0
     }
 };

--- a/database/migrations/2026_05_28_000001_create_ls_webhook_deliveries_table.php
+++ b/database/migrations/2026_05_28_000001_create_ls_webhook_deliveries_table.php
@@ -12,7 +12,7 @@ use OzanKurt\Shield\Support\Migrations\ShieldBlueprint;
  * retry permanent failures from the dashboard.
  *
  * This table is the on-site equivalent of Stripe's "Webhook attempt"
- * timeline — without it, an operator faced with "events aren't reaching
+ * timeline, without it, an operator faced with "events aren't reaching
  * Central" has no way to tell whether the plugin sent + got rejected,
  * sent + got nothing, or never sent at all.
  */
@@ -33,7 +33,7 @@ return new class extends Migration
             $table->string('operation', 32)->index();         // webhook_ingest | heartbeat | test_ping | webhook_ingest_batch
             $table->string('target_url', 255);
             $table->string('payload_hash', 64)->index();      // sha256 of the raw signed body
-            // INT (max 4.2B) — single payloads can exceed 64KB with stack
+            // INT (max 4.2B), single payloads can exceed 64KB with stack
             // traces, and batch ingest pushes can be megabytes. The earlier
             // SMALLINT either threw on strict MySQL or silently clamped.
             $table->unsignedInteger('payload_bytes')->default(0);
@@ -45,16 +45,16 @@ return new class extends Migration
             $table->unsignedSmallInteger('http_status')->default(0);
             $table->string('response_excerpt', 512)->nullable();
 
-            // Retry tracking — populated by the queued job's middleware
+            // Retry tracking, populated by the queued job's middleware
             $table->unsignedTinyInteger('attempt_number')->default(1);
             $table->unsignedTinyInteger('max_attempts')->default(3);
 
-            // Timing — start vs completion for latency analytics
+            // Timing, start vs completion for latency analytics
             $table->timestamp('dispatched_at')->index();
             $table->timestamp('completed_at')->nullable();
             $table->unsignedInteger('duration_ms')->nullable();
 
-            // Source linkage — when this is forwarding a specific audit
+            // Source linkage, when this is forwarding a specific audit
             // log row, store the local id for cross-reference
             $table->unsignedBigInteger('audit_log_id')->nullable()->index();
 

--- a/database/migrations/2026_05_28_000002_widen_webhook_delivery_payload_bytes.php
+++ b/database/migrations/2026_05_28_000002_widen_webhook_delivery_payload_bytes.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Facades\Schema;
  * (wrong byte count in dashboard).
  *
  * batch_size already maxes at the controller-side limit (500), so SMALLINT
- * stays fine there — no widening needed for that column.
+ * stays fine there, no widening needed for that column.
  */
 return new class extends Migration
 {
@@ -27,7 +27,7 @@ return new class extends Migration
     {
         // Laravel 11+ no longer needs doctrine/dbal for ->change() but
         // this package still supports L9/L10. Use raw ALTER per driver
-        // for portability — and to skip the doctrine requirement.
+        // for portability, and to skip the doctrine requirement.
         $driver = DB::connection($this->connection)->getDriverName();
 
         match ($driver) {

--- a/database/migrations/2026_06_15_000001_create_ls_integrity_lookup_tables.php
+++ b/database/migrations/2026_06_15_000001_create_ls_integrity_lookup_tables.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private array $tables = [
+        'ls_integrity_statuses',
+        'ls_integrity_change_types',
+        'ls_integrity_comparison_bases',
+    ];
+
+    public function __construct()
+    {
+        $this->connection = config('shield.database.connection');
+    }
+
+    public function up(): void
+    {
+        foreach ($this->tables as $tableName) {
+            Schema::create($tableName, function (Blueprint $table) {
+                $table->id();
+                $table->string('name', 64)->unique();
+                $table->string('label', 128);
+                $table->text('description')->nullable();
+                $table->integer('sort_order')->default(0);
+                $table->json('meta')->nullable();
+                $table->timestamps();
+                $table->index('sort_order');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach (array_reverse($this->tables) as $tableName) {
+            Schema::dropIfExists($tableName);
+        }
+    }
+};

--- a/database/migrations/2026_06_15_000002_create_ls_integrity_baselines_table.php
+++ b/database/migrations/2026_06_15_000002_create_ls_integrity_baselines_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use OzanKurt\Shield\Support\Migrations\ShieldBlueprint;
+
+return new class extends Migration
+{
+    public function __construct()
+    {
+        $this->connection = config('shield.database.connection');
+    }
+
+    public function up(): void
+    {
+        Schema::create('ls_integrity_baselines', function (Blueprint $table) {
+            $table->id();
+            $table->string('disk');
+            $table->string('scope_fingerprint')->nullable();
+            $table->string('root_hash')->nullable();
+            $table->string('artifact_path')->nullable();
+            $table->string('algo', 32)->default('sha256');
+            $table->integer('files_total')->default(0);
+            $table->boolean('signed')->default(false);
+            $table->timestamp('blessed_at')->nullable();
+            ShieldBlueprint::applyStandard($table);
+
+            $table->index('disk');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ls_integrity_baselines');
+    }
+};

--- a/database/migrations/2026_06_15_000003_create_ls_integrity_runs_table.php
+++ b/database/migrations/2026_06_15_000003_create_ls_integrity_runs_table.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use OzanKurt\Shield\Support\Migrations\ShieldBlueprint;
+
+return new class extends Migration
+{
+    public function __construct()
+    {
+        $this->connection = config('shield.database.connection');
+    }
+
+    public function up(): void
+    {
+        Schema::create('ls_integrity_runs', function (Blueprint $table) {
+            $table->id();
+            ShieldBlueprint::applyCorrelationId($table);
+            $table->unsignedBigInteger('status_id');
+            $table->unsignedBigInteger('trigger_id');
+            $table->unsignedBigInteger('severity_id')->nullable();
+            $table->string('disk');
+            $table->string('scope_fingerprint')->nullable();
+            $table->string('baseline_root_hash')->nullable();
+            $table->string('current_root_hash')->nullable();
+            $table->integer('files_total')->default(0);
+            $table->integer('files_hashed')->default(0);
+            $table->integer('files_size_only')->default(0);
+            $table->integer('files_unreadable')->default(0);
+            $table->integer('files_excluded')->default(0);
+            $table->integer('count_new')->default(0);
+            $table->integer('count_modified')->default(0);
+            $table->integer('count_deleted')->default(0);
+            $table->integer('count_scope_changed')->default(0);
+            $table->integer('count_vs_known_good')->default(0);
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('finished_at')->nullable();
+            $table->integer('duration_ms')->nullable();
+            $table->text('error_message')->nullable();
+            ShieldBlueprint::applyStandard($table);
+
+            $table->index('status_id');
+            $table->index('disk');
+            $table->foreign('status_id')->references('id')->on('ls_integrity_statuses');
+            $table->foreign('trigger_id')->references('id')->on('ls_scanner_triggers');
+            $table->foreign('severity_id')->references('id')->on('ls_log_levels');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ls_integrity_runs');
+    }
+};

--- a/database/migrations/2026_06_15_000004_create_ls_integrity_changes_table.php
+++ b/database/migrations/2026_06_15_000004_create_ls_integrity_changes_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use OzanKurt\Shield\Support\Migrations\ShieldBlueprint;
+
+return new class extends Migration
+{
+    public function __construct()
+    {
+        $this->connection = config('shield.database.connection');
+    }
+
+    public function up(): void
+    {
+        Schema::create('ls_integrity_changes', function (Blueprint $table) {
+            $table->id();
+            ShieldBlueprint::applyCorrelationId($table);
+            $table->unsignedBigInteger('integrity_run_id');
+            $table->unsignedBigInteger('change_type_id');
+            $table->unsignedBigInteger('compared_to_id');
+            $table->unsignedBigInteger('severity_id')->nullable();
+            $table->string('path', 1024);
+            $table->string('old_hash', 128)->nullable();
+            $table->string('new_hash', 128)->nullable();
+            $table->unsignedBigInteger('size_bytes')->nullable();
+            $table->timestamp('file_mtime')->nullable();
+            $table->string('symlink_target', 1024)->nullable();
+            ShieldBlueprint::applyStandard($table);
+
+            $table->index('integrity_run_id');
+            $table->index('change_type_id');
+            $table->index('compared_to_id');
+            $table->index('severity_id');
+            $table->foreign('integrity_run_id')->references('id')->on('ls_integrity_runs');
+            $table->foreign('change_type_id')->references('id')->on('ls_integrity_change_types');
+            $table->foreign('compared_to_id')->references('id')->on('ls_integrity_comparison_bases');
+            $table->foreign('severity_id')->references('id')->on('ls_log_levels');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('ls_integrity_changes');
+    }
+};

--- a/database/seeders/BuiltinWafRuleSeeder.php
+++ b/database/seeders/BuiltinWafRuleSeeder.php
@@ -42,7 +42,7 @@ class BuiltinWafRuleSeeder extends Seeder
     private function ruleDefinitions(): array
     {
         return [
-            // XSS — extracted from old config/security.php
+            // XSS, extracted from old config/security.php
             ['ref' => 'xss.evil_attributes',         'category' => 'xss',  'name' => 'Evil starting attributes',
              'pattern' => '#(<[^>]+[\x00-\x20\"\'\/])(form|formaction|on\w*|style|xmlns|xlink:href)[^>]*>?#iUu', 'severity' => 'high'],
             ['ref' => 'xss.protocols',               'category' => 'xss',  'name' => 'javascript:/livescript:/vbscript:/mocha:/feed:/data: protocols',

--- a/database/seeders/LookupTableSeeder.php
+++ b/database/seeders/LookupTableSeeder.php
@@ -8,6 +8,9 @@ use OzanKurt\Shield\Models\Lookups\AclKind;
 use OzanKurt\Shield\Models\Lookups\ActionKind;
 use OzanKurt\Shield\Models\Lookups\AuditLogKind;
 use OzanKurt\Shield\Models\Lookups\AuthEventKind;
+use OzanKurt\Shield\Models\Lookups\IntegrityChangeType;
+use OzanKurt\Shield\Models\Lookups\IntegrityComparisonBasis;
+use OzanKurt\Shield\Models\Lookups\IntegrityStatus;
 use OzanKurt\Shield\Models\Lookups\LogKind;
 use OzanKurt\Shield\Models\Lookups\LogLevel;
 use OzanKurt\Shield\Models\Lookups\ScannerBackend;
@@ -42,6 +45,9 @@ class LookupTableSeeder extends Seeder
         $this->seedScannerStatuses();
         $this->seedScannerFindingStatuses();
         $this->seedScannerTriggers();
+        $this->seedIntegrityStatuses();
+        $this->seedIntegrityChangeTypes();
+        $this->seedIntegrityComparisonBases();
     }
 
     private function seedAclKinds(): void
@@ -374,6 +380,68 @@ class LookupTableSeeder extends Seeder
 
         foreach ($triggers as [$name, $label, $description, $sort]) {
             ScannerTrigger::updateOrCreate(['name' => $name], [
+                'label' => $label,
+                'description' => $description,
+                'sort_order' => $sort,
+            ]);
+        }
+    }
+
+    private function seedIntegrityStatuses(): void
+    {
+        $statuses = [
+            ['running', 'Running', 'Integrity scan in progress', 10],
+            ['completed', 'Completed', 'Scan finished successfully', 20],
+            ['failed', 'Failed', 'Scan terminated due to error', 30],
+            ['baseline_established', 'Baseline Established', 'Provisional baseline created on first run, not yet trusted', 40],
+            ['tamper_suspected', 'Tamper Suspected', 'Baseline signature verification failed', 50],
+            ['incomplete', 'Incomplete', 'Remote read degraded; results not trustworthy', 60],
+            ['timed_out', 'Timed Out', 'Scan exceeded the max runtime budget', 70],
+            ['skipped', 'Skipped', 'Another run held the lock', 80],
+            ['aborted_limit', 'Aborted (limit)', 'File or iteration cap exceeded', 90],
+            ['cancelled', 'Cancelled', 'Scan cancelled by user', 100],
+        ];
+
+        foreach ($statuses as [$name, $label, $description, $sort]) {
+            IntegrityStatus::updateOrCreate(['name' => $name], [
+                'label' => $label,
+                'description' => $description,
+                'sort_order' => $sort,
+            ]);
+        }
+    }
+
+    private function seedIntegrityChangeTypes(): void
+    {
+        $types = [
+            ['new', 'New', 'File present now but not in the comparison set', 10],
+            ['modified', 'Modified', 'File content hash changed', 20],
+            ['deleted', 'Deleted', 'File was tracked but is now absent', 30],
+            ['scope_changed', 'Scope Changed', 'File entered or left scope due to a config change', 40],
+            ['became_unreadable', 'Became Unreadable', 'Tracked file is present but could not be read', 50],
+            ['vanished', 'Vanished', 'File disappeared mid-scan', 60],
+            ['volatile', 'Volatile', 'File changed again during the scan; excluded from escalation', 70],
+            ['symlink_new', 'New Symlink', 'A symlink that did not exist in the comparison set', 80],
+        ];
+
+        foreach ($types as [$name, $label, $description, $sort]) {
+            IntegrityChangeType::updateOrCreate(['name' => $name], [
+                'label' => $label,
+                'description' => $description,
+                'sort_order' => $sort,
+            ]);
+        }
+    }
+
+    private function seedIntegrityComparisonBases(): void
+    {
+        $bases = [
+            ['last_run', 'Last Run', 'Compared against the previous scan run (per-run delta)', 10],
+            ['known_good', 'Known Good', 'Compared against the pinned approved baseline', 20],
+        ];
+
+        foreach ($bases as [$name, $label, $description, $sort]) {
+            IntegrityComparisonBasis::updateOrCreate(['name' => $name], [
                 'label' => $label,
                 'description' => $description,
                 'sort_order' => $sort,

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ Comprehensive Laravel security suite — WAF, malware scanner, ACL, audit log, l
 |---|---|
 | [Audit log](audit-log.md) | HMAC-chained tamper-evident audit trail with file/config/composer drift detection |
 | [Scanner](scanner.md) | Native + ClamAV + composer-audit backends, signature sync, quarantine + restore |
+| [File integrity](integrity.md) | Baseline diff + grouped New/Modified/Deleted summary to mail/Slack/Discord |
 | [File watcher](security-watch.md) | `shield:watch` long-running command for real-time file-change detection |
 | [Dashboard](dashboard.md) | Bootstrap dashboard page tour + the cache management page |
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,20 +1,20 @@
 # Laravel Shield Documentation
 
-Comprehensive Laravel security suite — WAF, malware scanner, ACL, audit log, live traffic, and notifications.
+Comprehensive Laravel security suite, WAF, malware scanner, ACL, audit log, live traffic, and notifications.
 
 ## Getting started
 
 | Topic | What |
 |---|---|
 | [Installation](installation.md) | `composer require` + `shield:install` flow, post-install setup, optional dependencies |
-| [Configuration](configuration.md) | Every config key in `config/shield.php` explained — storage drivers, caching, sampling, retention |
+| [Configuration](configuration.md) | Every config key in `config/shield.php` explained, storage drivers, caching, sampling, retention |
 | [Architecture](architecture.md) | Contracts, service container bindings, extension points, premium hook design |
 
 ## Defense layers
 
 | Topic | What |
 |---|---|
-| [ACL — Access Control List](acl.md) | Unified allow/deny across IP/CIDR/ASN/country/regex with first-match-wins evaluation |
+| [ACL, Access Control List](acl.md) | Unified allow/deny across IP/CIDR/ASN/country/regex with first-match-wins evaluation |
 | [Middleware reference](middleware.md) | Every `firewall.*` alias + what it does + when to attach it |
 | [Bypass mechanism](bypass.md) | Three-layer admin lockout recovery: env key, config IPs, Artisan commands |
 
@@ -51,9 +51,9 @@ Comprehensive Laravel security suite — WAF, malware scanner, ACL, audit log, l
 
 ## Companion packages
 
-- [`ozankurt/laravel-shield-filament`](https://github.com/OzanKurt/laravel-shield-filament) — Filament panel adapter. v1.x for Filament 3+4. v2.x for Filament 5+.
-- [`ozankurt/laravel-shield-signatures`](https://github.com/OzanKurt/laravel-shield-signatures) — Public signature feed consumed by `shield:signatures-sync`.
+- [`ozankurt/laravel-shield-filament`](https://github.com/OzanKurt/laravel-shield-filament), Filament panel adapter. v1.x for Filament 3+4. v2.x for Filament 5+.
+- [`ozankurt/laravel-shield-signatures`](https://github.com/OzanKurt/laravel-shield-signatures), Public signature feed consumed by `shield:signatures-sync`.
 
 ## Brand site
 
-[laravel-shield.ozankurt.com](https://laravel-shield.ozankurt.com) — pricing, license activation, support.
+[laravel-shield.ozankurt.com](https://laravel-shield.ozankurt.com), pricing, license activation, support.

--- a/docs/acl.md
+++ b/docs/acl.md
@@ -1,14 +1,14 @@
-# ACL — Unified Access Control List
+# ACL, Unified Access Control List
 
-The `ls_acl` table holds every allow/deny entry — IPs, CIDR ranges, ASNs, countries, regexes — in one place. The `firewall.acl` middleware evaluates entries first-match-wins per tier and short-circuits the request when it finds a match.
+The `ls_acl` table holds every allow/deny entry, IPs, CIDR ranges, ASNs, countries, regexes, in one place. The `firewall.acl` middleware evaluates entries first-match-wins per tier and short-circuits the request when it finds a match.
 
 ## Evaluation order
 
 For each request, the evaluator checks tiers in this order:
 
-1. **Whitelist** (`action=allow`) — any match → ALLOW (request continues; later firewall middlewares skipped)
-2. **Blacklist** (`action=blacklist`, permanent) — any match → DENY (403)
-3. **Block** (`action=block`, usually with `expires_at`) — any match → DENY (403)
+1. **Whitelist** (`action=allow`), any match → ALLOW (request continues; later firewall middlewares skipped)
+2. **Blacklist** (`action=blacklist`, permanent), any match → DENY (403)
+3. **Block** (`action=block`, usually with `expires_at`), any match → DENY (403)
 4. No match → PASS (request continues, subject to remaining firewall middlewares)
 
 Within each tier: first match wins. Across kinds: IP-exact matches are checked first (cheapest), then CIDR, then user-agent / referrer regex, then country, region, city, ASN, hostname (only when configured).
@@ -21,7 +21,7 @@ Within each tier: first match wins. Across kinds: IP-exact matches are checked f
 | `cidr` | `10.0.0.0/24`, `2001:db8::/32` | O(N) via Symfony IpUtils |
 | `asn` | `AS12345` (1.1+, requires `geoip2/geoip2`) | O(1) MaxMind DB lookup |
 | `country` / `region` / `city` | ISO 3166 code or name | O(1) MaxMind DB lookup |
-| `hostname` | reverse-DNS name | DNS call — opt-in, off by default |
+| `hostname` | reverse-DNS name | DNS call, opt-in, off by default |
 | `ua_regex` | PHP regex matched against User-Agent | O(N) |
 | `ref_regex` | PHP regex matched against Referer | O(N) |
 
@@ -45,7 +45,7 @@ The `BlockAclEntryListener` creates an `ls_acl` row with `action=block`, `source
 
 ## Caching
 
-- Full live ACL: `Cache::rememberForever('shield.acl.live')` — invalidated on any `ls_acl` write via `AclObserver`
+- Full live ACL: `Cache::rememberForever('shield.acl.live')`, invalidated on any `ls_acl` write via `AclObserver`
 - Per-IP decision: `shield.acl.decision.<md5(ip|ua)>` with TTL from `shield.acl.decision_cache_ttl` (default 60s)
 - GeoIP / ASN per-IP: cached per request lifetime
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -173,10 +173,10 @@ All in `ShieldServiceProvider::register()`:
 | Binding | Resolves to |
 |---|---|
 | `Shield::class` + `'shield'` alias | The main `Shield` facade target |
-| `LookupResolver::class` | Singleton — cached name→id lookups |
+| `LookupResolver::class` | Singleton, cached name→id lookups |
 | `AclEvaluator::class` | Singleton |
 | `WafRuleResolver::class` | Singleton |
-| `HmacChain::class` | Singleton — wraps `LS_AUDIT_HMAC_SECRET` |
+| `HmacChain::class` | Singleton, wraps `LS_AUDIT_HMAC_SECRET` |
 | `AuditLogger::class` | Singleton |
 | `Scanner::class` | Singleton, backends array assembled from contract bindings |
 | `SuspicionScorer::class` | Singleton |
@@ -224,9 +224,9 @@ Event::listen(\OzanKurt\Shield\Events\AttackDetectedEvent::class, function ($eve
 
 | Table | Schema purpose |
 |---|---|
-| `ls_logs` | Attack/firewall-hit records — IP, middleware, URL, request_data |
+| `ls_logs` | Attack/firewall-hit records, IP, middleware, URL, request_data |
 | `ls_auth_logs` | Login attempts |
-| `ls_acl` | Unified allow/deny list — kind_id, value, action_id, expires_at |
+| `ls_acl` | Unified allow/deny list, kind_id, value, action_id, expires_at |
 | `ls_audit_log` | HMAC-chained admin/state-change trail |
 | `ls_waf_rules` | DB-backed firewall rules (replaces `config/security.php` regex arrays) |
 | `ls_signatures` | Malware signatures from the GitHub-Releases feed |
@@ -241,7 +241,7 @@ Every model implements `HasUuid` + `HasUserstamps` + `SoftDeletes` and is bound 
 The FK-to-lookup-table pattern beats `EnumCasts::class` because:
 - Lookup values can be added at runtime by feed providers (e.g. ClamAV signature categories) without code changes
 - Cross-DB compatibility (MySQL ENUM differs from Postgres ENUM)
-- Visibility — every value exists as a queryable row, surfaceable in the dashboard
+- Visibility, every value exists as a queryable row, surfaceable in the dashboard
 
 `LookupResolver` caches the name↔id mapping forever (invalidated only by manual `cache:clear`), so the FK joins cost nothing in the hot path.
 
@@ -251,4 +251,4 @@ The package was renamed from `ozankurt/laravel-security` to `ozankurt/laravel-sh
 
 ## Octane / Reverb compatibility
 
-Singletons that hold per-request state (`CorrelationId`, `CspNonce`, `Shield::$ipWhitelistedInDatabase`) need to be reset between requests under Octane. Shield's `ShieldServiceProvider::boot()` registers a Laravel `RequestHandled` listener (or Octane equivalent) to reset these — verify yours is firing before deploying under Octane in production.
+Singletons that hold per-request state (`CorrelationId`, `CspNonce`, `Shield::$ipWhitelistedInDatabase`) need to be reset between requests under Octane. Shield's `ShieldServiceProvider::boot()` registers a Laravel `RequestHandled` listener (or Octane equivalent) to reset these, verify yours is firing before deploying under Octane in production.

--- a/docs/audit-log.md
+++ b/docs/audit-log.md
@@ -1,4 +1,4 @@
-# Audit log — Tamper-evident security audit trail
+# Audit log, Tamper-evident security audit trail
 
 The `ls_audit_log` table captures admin/security-sensitive state changes. Every record stores an HMAC of its content + the previous record's HMAC, forming a chain. Modifying or deleting a record breaks the chain, and `shield:audit-verify` reports the first broken link.
 
@@ -21,8 +21,8 @@ The `ls_audit_log` table captures admin/security-sensitive state changes. Every 
 ## Tamper evidence
 
 Each record stores:
-- `prev_hash` — the previous record's `hmac` (or null for the first row)
-- `hmac` — HMAC-SHA256 of canonicalized record JSON + prev_hash, signed with `LS_AUDIT_HMAC_SECRET`
+- `prev_hash`, the previous record's `hmac` (or null for the first row)
+- `hmac`, HMAC-SHA256 of canonicalized record JSON + prev_hash, signed with `LS_AUDIT_HMAC_SECRET`
 
 Modifying any field of any record changes its HMAC; subsequent records' HMACs are now misaligned with what `prev_hash` says they should be.
 

--- a/docs/bypass.md
+++ b/docs/bypass.md
@@ -1,4 +1,4 @@
-# Bypass — Admin Lockout Recovery
+# Bypass, Admin Lockout Recovery
 
 Three independent layers, all audit-logged when used. Pick the one that fits your situation; combine them for defense in depth.
 
@@ -26,7 +26,7 @@ Audit-logged as `bypass.used` with `mechanism=header_key`.
 LS_BYPASS_IPS=203.0.113.5,2001:db8::/32
 ```
 
-Comma-separated list of IPs or CIDR ranges. These IPs ALWAYS bypass everything, can never be auto-blocked, and can't be removed from the dashboard — only by editing `.env`.
+Comma-separated list of IPs or CIDR ranges. These IPs ALWAYS bypass everything, can never be auto-blocked, and can't be removed from the dashboard, only by editing `.env`.
 
 **When to use:** office static IPs, your home IP, dev/staging server IPs, infrastructure admin IPs.
 
@@ -48,7 +48,7 @@ When any of the three layers fires:
 
 - `firewall.acl` short-circuits (no blacklist/block enforcement)
 - `firewall.live_traffic` still records (so the bypass usage is visible)
-- Domain firewall middlewares (xss / sqli / lfi / etc.) **still run** — bypass doesn't disable WAF rule evaluation, only the IP-level ACL gate
+- Domain firewall middlewares (xss / sqli / lfi / etc.) **still run**, bypass doesn't disable WAF rule evaluation, only the IP-level ACL gate
 
 If you need to bypass WAF rules too, attach `firewall.bypass` middleware to your route explicitly.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Every behavior is exposed in `config/shield.php`. After `composer require` + `shield:install`, you have a published copy in your app — edit it directly. This page is the authoritative reference.
+Every behavior is exposed in `config/shield.php`. After `composer require` + `shield:install`, you have a published copy in your app, edit it directly. This page is the authoritative reference.
 
 ## Top-level keys
 
@@ -49,9 +49,9 @@ Every behavior is exposed in `config/shield.php`. After `composer require` + `sh
 ],
 ```
 
-- `sync` — every write is a synchronous Eloquent save. Default. Fine for low-medium traffic.
-- `queue` — every write dispatches a job. Requires a queue worker (`php artisan queue:work --queue=shield`). Use for medium-high traffic.
-- `redis_batch` — buffers in Redis sorted set, flushes every `batch_interval` seconds. Highest throughput. Requires Redis.
+- `sync`, every write is a synchronous Eloquent save. Default. Fine for low-medium traffic.
+- `queue`, every write dispatches a job. Requires a queue worker (`php artisan queue:work --queue=shield`). Use for medium-high traffic.
+- `redis_batch`, buffers in Redis sorted set, flushes every `batch_interval` seconds. Highest throughput. Requires Redis.
 
 Sampling applies to live_traffic non-attack rows. Attacks always 100%.
 
@@ -94,7 +94,7 @@ Gate::define('viewShieldDashboard', fn ($user) => $user && $user->is_admin);
 
 ## Bypass mechanism
 
-See [bypass.md](bypass.md) — three layers:
+See [bypass.md](bypass.md), three layers:
 
 1. `LS_BYPASS_KEY` env (32+ char random string, sent as `X-Security-Bypass` header)
 2. `LS_BYPASS_IPS` env (comma-separated IP/CIDR list)

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -23,7 +23,7 @@ The `ShieldDashboardMiddleware` calls `Gate::allows('viewShieldDashboard')` on e
 |---|---|---|
 | `/shield` | Dashboard | Stats cards (attacks, ACL active, recent events), recently modified files widget |
 | `/shield/acl` | ACL | Unified allow/deny entries with kind/value/action/source filters, per-row whitelist/blacklist/delete |
-| `/shield/logs` | Attack logs | Every `AttackDetectedEvent` row from the firewall middlewares — searchable, paginated |
+| `/shield/logs` | Attack logs | Every `AttackDetectedEvent` row from the firewall middlewares, searchable, paginated |
 | `/shield/auth-logs` | Auth logs | Login attempts (success + failure) emitted by Laravel `Auth::Login` / `Auth::Failed` events |
 | `/shield/audit-log` | Audit log | HMAC-chained admin/state-change trail, filterable by kind + severity + actor + correlation_id |
 | `/shield/live-traffic` | Live traffic | Sampled traffic stream with 5–10s polling (or real-time when broadcasting enabled) |
@@ -67,7 +67,7 @@ Supported `type` values:
 | `confirmDialog` | Open a confirm dialog before the action commits (planned) |
 | `redirect` | Redirect to a new URL (planned) |
 
-Custom controllers in your app can return the same shape — the dashboard's `ajaxComplete` handler will process the actions automatically when called via the standard ajax pattern.
+Custom controllers in your app can return the same shape, the dashboard's `ajaxComplete` handler will process the actions automatically when called via the standard ajax pattern.
 
 ## Mobile responsiveness
 
@@ -81,7 +81,7 @@ Every table uses DataTables.net's `responsive: true` mode. Columns collapse into
 - An auto-block isn't firing and you suspect the per-IP decision cache is stale
 - After a deploy, signature/rule changes aren't visible in the dashboard
 
-The "Clear all" button purges every `shield.*` key in one go — useful after a major schema migration.
+The "Clear all" button purges every `shield.*` key in one go, useful after a major schema migration.
 
 ## Theme switcher
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -41,12 +41,12 @@ Runs `EnvAuditor::audit()` which checks:
 
 A weighted score across the env audit findings produces a grade A–F:
 
-- **A** — no findings
-- **B** — score ≤ 2 (low-severity items only)
-- **C** — score ≤ 5
-- **D** — score ≤ 10
-- **E** — score ≤ 20
-- **F** — score > 20
+- **A**, no findings
+- **B**, score ≤ 2 (low-severity items only)
+- **C**, score ≤ 5
+- **D**, score ≤ 10
+- **E**, score ≤ 20
+- **F**, score > 20
 
 Weights: critical = 10, high = 5, medium = 2, low = 1.
 
@@ -102,9 +102,9 @@ The "Required updates" section of every multi-cadence report (daily digest, 7-da
 
 ## Operator workflow
 
-1. **After every dependency update** — run `shield:scan --backend=composer_audit` (or wait for the scheduled run) to refresh CVE state
-2. **Before going to production** — visit `/shield/diagnostics` and aim for grade A or B
-3. **On a stale install** — visit `/shield/composer-audit` for CVEs that accumulated since last `composer update`
+1. **After every dependency update**, run `shield:scan --backend=composer_audit` (or wait for the scheduled run) to refresh CVE state
+2. **Before going to production**, visit `/shield/diagnostics` and aim for grade A or B
+3. **On a stale install**, visit `/shield/composer-audit` for CVEs that accumulated since last `composer update`
 
 ## CLI shortcuts
 
@@ -119,7 +119,7 @@ php artisan shield:diag
 php artisan shield:composer-audit
 ```
 
-`shield:diag` is the right command to ask users to run when filing a bug — it captures everything the diagnostics page shows, plus version pins from `composer.lock`.
+`shield:diag` is the right command to ask users to run when filing a bug, it captures everything the diagnostics page shows, plus version pins from `composer.lock`.
 
 ## Troubleshooting
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,7 +5,7 @@ composer require ozankurt/laravel-shield
 php artisan shield:install
 ```
 
-`shield:install` is idempotent — safe to re-run.
+`shield:install` is idempotent, safe to re-run.
 
 ## What the install command does
 
@@ -47,12 +47,12 @@ php artisan queue:work --queue=shield
 
 ## Schedule
 
-Add Shield's scheduled tasks to your scheduler. Shield self-registers when `shield.audit.drift.enabled` etc. are true — if your scheduler is `php artisan schedule:run` (cron every minute), there's nothing else to do.
+Add Shield's scheduled tasks to your scheduler. Shield self-registers when `shield.audit.drift.enabled` etc. are true, if your scheduler is `php artisan schedule:run` (cron every minute), there's nothing else to do.
 
 Common scheduled commands:
-- `shield:audit-drift` (daily 4am) — re-checksum monitored files
-- `shield:signatures-sync` (daily 5am) — pull latest signatures from GitHub releases
-- `shield:unblock-ips` — ACL expiry sweep
+- `shield:audit-drift` (daily 4am), re-checksum monitored files
+- `shield:signatures-sync` (daily 5am), pull latest signatures from GitHub releases
+- `shield:unblock-ips`, ACL expiry sweep
 
 ## Optional dependencies (composer suggests)
 

--- a/docs/integrity.md
+++ b/docs/integrity.md
@@ -1,0 +1,128 @@
+# File integrity monitoring
+
+Scan the filesystem, diff it against an approved baseline, and post a grouped
+"New / Modified / Deleted" summary to mail / Slack / Discord. The Wordfence file
+integrity check, for Laravel.
+
+```
+File integrity scan — app (2026-06-15 12:07 UTC)
+8 new · 2 modified · 0 deleted · 92106 files total
+🚩 New (8): public/cache/ff/3776/footer.php · ...
+✏️ Modified (2): public/error_log · ...
+```
+
+## How it works
+
+Each run builds a manifest of file hashes for a configured disk and compares it
+two ways (hybrid):
+
+- **Per-run delta** (vs the previous run): low-noise, drives the card.
+- **Drift vs the pinned known-good baseline**: persists until you re-approve, so slow tampering keeps surfacing.
+
+## Quick start
+
+```bash
+echo "LS_INTEGRITY_ENABLED=true" >> .env
+echo "LS_INTEGRITY_HMAC_KEY=$(php -r 'echo bin2hex(random_bytes(32));')" >> .env
+
+# First run establishes a PROVISIONAL baseline from the current disk state.
+# It is NOT trusted yet (your host could already be compromised). Review, then approve.
+php artisan shield:integrity
+
+php artisan shield:integrity-status
+php artisan shield:integrity-bless     # approve the reviewed baseline
+
+# Later runs diff against the approved baseline and fire the notification on changes.
+php artisan shield:integrity
+```
+
+Or from the dashboard at `/shield/integrity`: "Run scan" and "Approve baseline".
+
+## Why the first run is not trusted
+
+FIM is often installed onto an already-infected host. If the first scan silently
+trusted "whatever is on disk", a webshell present at install would be baked into
+the baseline and never reported again. So `auto_bless_on_first_run` defaults to
+`false`: the first run records a `baseline_established` status, raises a loud
+"review before trusting" notice, and you must `shield:integrity-bless` to approve it.
+
+## Commands
+
+```bash
+php artisan shield:integrity            # run a scan (--disk, --trigger)
+php artisan shield:integrity-bless      # approve the latest state as known-good (--disk)
+php artisan shield:integrity-status     # latest run + baseline state (--disk)
+php artisan shield:integrity-prune      # hard-delete runs/changes past retention
+php artisan shield:integrity-heartbeat  # warn if scans have silently stopped (--disk)
+```
+
+Enable the schedule with `LS_INTEGRITY_SCHEDULE_ENABLED=true` (default cron hourly).
+The scheduler also wires nightly pruning and an hourly heartbeat.
+
+## Severity
+
+A configurable, ordered, first-match ruleset (`shield.integrity.severity_rules`)
+scores each change. The defaults:
+
+| Severity | Matches |
+|---|---|
+| **critical** | new/modified script file (`.php`, `.phtml`, ...) under a web-reachable docroot (`public/`) — the classic dropped webshell |
+| **high** | new/modified `.php` in `app/ routes/ config/`; any deletion; any change under `vendor/` |
+| **medium** | `.env` / `.htaccess` / `.user.ini` changes; a file that became unreadable |
+| **low** | everything else |
+
+Script-extension files are always hashed (even over `max_file_size`), so an
+attacker cannot hide a backdated/oversized payload.
+
+## Baseline integrity
+
+The known-good baseline is a gzipped NDJSON artifact, written atomically and
+HMAC-signed. A signature that fails to verify is reported as `tamper_suspected`
+(critical) and the baseline is **not** rebuilt. The root hash is stored in the
+DB and audit chain as well.
+
+Honest limitation: on a fully compromised host the attacker can read the key and
+re-sign, so the HMAC defends against unprivileged `storage/` writes and accidental
+corruption, not a root compromise. Off-box attestation (via the Central app) is a
+later phase. Keep the key in a file outside the web root: `LS_INTEGRITY_HMAC_KEY_PATH`.
+
+## Notifications
+
+Routed through the standard notification config. Enable the event and pick channels:
+
+```env
+FIREWALL_NOTIFICATIONS_INTEGRITY_CHANGED_ENABLED=true
+```
+
+```php
+// config/shield.php
+'notifications' => [
+    'integrity_changed' => ['enabled' => ..., 'channels' => ['mail', 'discord']],
+],
+```
+
+The card leads with the per-run delta and carries a "N files differ from the
+approved baseline" drift line. Zero-delta runs are suppressed
+(`integrity.notify.suppress_when_no_changes`), but security/operational events
+(`tamper_suspected`, `baseline_established`, `failed`, `aborted_limit`) always
+notify. Per-channel limits are respected and the highest-severity paths are shown
+first, never truncated into "+N more".
+
+## Configuration
+
+The full `shield.integrity` block lives in `config/shield.php`: `disks` (roots +
+include/exclude globs + `follow_symlinks` + `max_file_size`), `schedule`,
+`baseline` (`auto_bless_on_first_run`, `hmac_key_path`, `hmac_key`), `limits`
+(`max_files`, `max_iterations`, `max_runtime`, `max_persisted_changes_per_run`),
+`notify`, `retention`, `heartbeat`, and `severity_rules`.
+
+The default `app` disk scans `base_path()` excluding `vendor/`, `node_modules/`,
+`.git/`, `storage/framework/`, `storage/logs/`, `bootstrap/cache/`, and
+`storage/shield/` (where the baseline artifact lives).
+
+## Scope notes
+
+- Phase 1 targets the **local filesystem** (`hash_file` streams, so memory stays flat).
+- Remote disks (sftp/s3) via the `Storage` abstraction, an S3 ETag pre-filter, a
+  `composer.lock` dist-hash cross-check, and premium real-time monitoring are later phases.
+- The existing `config_drift` scanner target overlaps narrowly and is unchanged.

--- a/docs/integrity.md
+++ b/docs/integrity.md
@@ -5,7 +5,7 @@ Scan the filesystem, diff it against an approved baseline, and post a grouped
 integrity check, for Laravel.
 
 ```
-File integrity scan — app (2026-06-15 12:07 UTC)
+File integrity scan: app (2026-06-15 12:07 UTC)
 8 new · 2 modified · 0 deleted · 92106 files total
 🚩 New (8): public/cache/ff/3776/footer.php · ...
 ✏️ Modified (2): public/error_log · ...
@@ -66,7 +66,7 @@ scores each change. The defaults:
 
 | Severity | Matches |
 |---|---|
-| **critical** | new/modified script file (`.php`, `.phtml`, ...) under a web-reachable docroot (`public/`) — the classic dropped webshell |
+| **critical** | new/modified script file (`.php`, `.phtml`, ...) under a web-reachable docroot (`public/`), the classic dropped webshell |
 | **high** | new/modified `.php` in `app/ routes/ config/`; any deletion; any change under `vendor/` |
 | **medium** | `.env` / `.htaccess` / `.user.ini` changes; a file that became unreadable |
 | **low** | everything else |

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -46,7 +46,7 @@ Customize the order in `config/shield.php`:
 | `firewall.correlation` | `Http\Middleware\AttachCorrelationId` | Generates UUID7 per request; sets `X-Correlation-Id` response header. Accepts an existing incoming UUID via `X-Correlation-Id` request header. |
 | `firewall.bypass` | `Firewall\Middleware\Bypass` | Checks `X-Security-Bypass` header against `LS_BYPASS_KEY` + checks client IP against `shield.bypass.ips`. On match, sets `shield.bypassed` attribute → later middlewares short-circuit. Audit-logs every bypass. |
 | `firewall.acl` | `Firewall\Middleware\Acl` | Evaluates `ls_acl` first-match-wins (allow > blacklist > block > pass). 403 on deny. |
-| `firewall.live_traffic` | `Http\Middleware\LiveTrafficCapture` | Terminable middleware — records the request after response is sent. Sampling per `shield.live_traffic.sample_rate`. |
+| `firewall.live_traffic` | `Http\Middleware\LiveTrafficCapture` | Terminable middleware, records the request after response is sent. Sampling per `shield.live_traffic.sample_rate`. |
 
 ### WAF detectors (port-from-config in beta.1)
 
@@ -54,7 +54,7 @@ Each loads patterns from `ls_waf_rules` filtered by category. On match: blocks (
 
 | Alias | Category | Detects |
 |---|---|---|
-| `firewall.ip` | n/a | DB-tracked block/blacklist entries (older `security_ips` model — being deprecated in favor of `firewall.acl`) |
+| `firewall.ip` | n/a | DB-tracked block/blacklist entries (older `security_ips` model, being deprecated in favor of `firewall.acl`) |
 | `firewall.agent` | `agent` | Browser/platform/device/property allow-block + malicious UA patterns |
 | `firewall.bot` | `bot` | Crawler allow-block (Googlebot, Bingbot, scrapers) |
 | `firewall.geo` | n/a | Continent/country/region/city filtering via configurable provider (`ipapi`, `ipstack`, etc.) |
@@ -108,7 +108,7 @@ Every detector middleware accepts a uniform shape under `shield.middleware.<name
             'period' => 1800,             // block duration in seconds
         ],
         'patterns' => [
-            // legacy — beta.1 migrates this list into ls_waf_rules
+            // legacy, beta.1 migrates this list into ls_waf_rules
             '#[\d\W]union select#i',
         ],
     ],

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -9,8 +9,8 @@ Five channels. Severity-routed. Throttled. Multi-cadence reports.
 | `mail` | Built-in |
 | `slack` | Built-in |
 | `discord` | Built-in (custom channel) |
-| `telegram` | Built-in (1.0+) — Bot API, MarkdownV2 |
-| `webhook` | Built-in (1.0+) — generic POST + stable payload for the future Central app |
+| `telegram` | Built-in (1.0+), Bot API, MarkdownV2 |
+| `webhook` | Built-in (1.0+), generic POST + stable payload for the future Central app |
 
 ## Routing matrix
 

--- a/docs/plans/2026-06-15-integrity-phase1-notification-prerequisites.md
+++ b/docs/plans/2026-06-15-integrity-phase1-notification-prerequisites.md
@@ -1,0 +1,282 @@
+# Integrity Phase 1 - Notification Prerequisites Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the three shared notification-layer defects that the upcoming file-integrity summary card depends on, so that mail/Slack/Discord delivery actually resolves and renders.
+
+**Architecture:** This is the first of five sequenced plans implementing spec-005 ([docs/specs/spec-005-file-integrity-scan-notification.md](../specs/spec-005-file-integrity-scan-notification.md), Section 9). It touches only the shared notification plumbing: the missing Slack channel package, `Notifiable`'s wrong config paths, and the `DiscordMessage` serializer bugs. It deliberately does NOT repair the (separately broken) login/attack notifications, see "Out of scope" below.
+
+**Tech Stack:** PHP 8, Laravel 10 (package supports 9-12), Orchestra Testbench + PHPUnit, `laravel/slack-notification-channel`.
+
+---
+
+## Context the implementer needs
+
+- This is a Composer **package** (`ozankurt/laravel-shield`), not an app. Tests run via Orchestra Testbench. The base test class is `OzanKurt\Shield\Tests\TestCase` ([tests/TestCase.php](../../tests/TestCase.php)); unit tests instantiate classes directly and set values with `config([...])`.
+- Run the full suite with `vendor/bin/phpunit`. Run one test with `vendor/bin/phpunit --filter test_name`.
+- The notification config has two layers ([config/shield.php:71-143](../../config/shield.php#L71)):
+  - `shield.notifications.<event>` = `{ enabled, channels: [...] }` (per-event toggles; `channels` is a flat list of channel names).
+  - `shield.notification_channels.<channel>` = delivery settings. For `mail` the recipient is `notification_channels.mail.to`; for `slack` the **incoming webhook URL** is `notification_channels.slack.to`; for `discord` the webhook is `notification_channels.discord.webhook_url`.
+- `OzanKurt\Shield\Notifications\Notifiable` ([src/Notifications/Notifiable.php](../../src/Notifications/Notifiable.php)) is the singleton routing target. It currently reads `shield.notifications.*` (the wrong layer), so mail/slack recipients resolve to `null`.
+- `OzanKurt\Shield\Notifications\Channels\Discord\DiscordMessage` ([src/Notifications/Channels/Discord/DiscordMessage.php](../../src/Notifications/Channels/Discord/DiscordMessage.php)) builds the Discord webhook payload. Its `toArray()` has three bugs (see Task 3).
+- Laravel 10 removed the legacy Slack notification channel from the framework. `Illuminate\Notifications\Messages\SlackMessage` does not exist until `laravel/slack-notification-channel` is installed. That package ships BOTH the legacy webhook `Messages\SlackMessage` (used here, routes via an incoming webhook URL) and the newer Block Kit API; a webhook-URL return from `routeNotificationForSlack()` selects the legacy webhook path, matching how Discord already works.
+
+## Out of scope (flag, do not fix here)
+
+`AttackDetectedNotification`, `FailedLoginNotification`, `SuccessfulLoginNotification`, and `SecurityReportNotification` are independently broken (wrong event key in `FailedLoginNotification::__construct`, `via()` iterating a flat list as if keyed, the `$this->$this->config` fatal in `viaQueues()`, and `$this->log`/`$this->notifications` references that do not exist). Repairing them is a separate bug-fix tracked outside this plan. This plan only fixes the SHARED pieces (Slack dependency, `Notifiable`, `DiscordMessage`) that the new integrity notification will reuse; the integrity notification (a later plan) implements its own correct `via()`.
+
+---
+
+## Task 1: Add the Slack notification channel package
+
+**Files:**
+- Modify: `composer.json` (require section)
+- Test: `tests/Unit/Notifications/SlackChannelAvailableTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+namespace OzanKurt\Shield\Tests\Unit\Notifications;
+
+use OzanKurt\Shield\Tests\TestCase;
+
+class SlackChannelAvailableTest extends TestCase
+{
+    public function test_legacy_slack_message_class_is_available(): void
+    {
+        $this->assertTrue(
+            class_exists(\Illuminate\Notifications\Messages\SlackMessage::class),
+            'laravel/slack-notification-channel must be installed so the legacy webhook SlackMessage exists.'
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit --filter test_legacy_slack_message_class_is_available`
+Expected: FAIL (assertion false; the class does not exist yet on Laravel 10).
+
+- [ ] **Step 3: Install the package**
+
+Run: `composer require laravel/slack-notification-channel`
+
+Let Composer resolve the version compatible with the installed Laravel. After install, verify the legacy class file is present:
+
+Run: `composer show laravel/slack-notification-channel`
+Expected: a version is listed, and `vendor/laravel/slack-notification-channel/src/Messages/SlackMessage.php` exists.
+
+If the resolved version does NOT ship `Illuminate\Notifications\Messages\SlackMessage` (legacy webhook), stop and report: the Slack rendering approach in spec-005 (legacy incoming webhook) assumes it. Do not silently switch to Block Kit, which requires a bot token.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit --filter test_legacy_slack_message_class_is_available`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add composer.json composer.lock tests/Unit/Notifications/SlackChannelAvailableTest.php
+git commit -m "feat(notifications): add laravel/slack-notification-channel for webhook Slack"
+```
+
+---
+
+## Task 2: Fix `Notifiable` to read the `notification_channels` config layer
+
+**Files:**
+- Modify: `src/Notifications/Notifiable.php:11-24`
+- Test: `tests/Unit/Notifications/NotifiableTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+namespace OzanKurt\Shield\Tests\Unit\Notifications;
+
+use OzanKurt\Shield\Notifications\Notifiable;
+use OzanKurt\Shield\Tests\TestCase;
+
+class NotifiableTest extends TestCase
+{
+    public function test_routes_resolve_from_notification_channels_layer(): void
+    {
+        config([
+            'shield.notification_channels.mail.to' => 'ops@example.com',
+            'shield.notification_channels.slack.to' => 'https://hooks.slack.com/services/T/B/x',
+            'shield.notification_channels.discord.webhook_url' => 'https://discord.com/api/webhooks/1/abc',
+        ]);
+
+        $notifiable = new Notifiable();
+
+        $this->assertSame('ops@example.com', $notifiable->routeNotificationForMail());
+        $this->assertSame('https://hooks.slack.com/services/T/B/x', $notifiable->routeNotificationForSlack());
+        $this->assertSame('https://discord.com/api/webhooks/1/abc', $notifiable->routeNotificationForDiscord());
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit --filter test_routes_resolve_from_notification_channels_layer`
+Expected: FAIL on the mail/slack assertions (current code reads `shield.notifications.mail.to` / `...slack.to`, which are unset, returning `null`).
+
+- [ ] **Step 3: Fix the route methods**
+
+Replace the three route methods in `src/Notifications/Notifiable.php`:
+
+```php
+    public function routeNotificationForMail()
+    {
+        return config('shield.notification_channels.mail.to');
+    }
+
+    public function routeNotificationForSlack()
+    {
+        return config('shield.notification_channels.slack.to'); // incoming webhook URL
+    }
+
+    public function routeNotificationForDiscord()
+    {
+        return config('shield.notification_channels.discord.webhook_url');
+    }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit --filter test_routes_resolve_from_notification_channels_layer`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Notifications/Notifiable.php tests/Unit/Notifications/NotifiableTest.php
+git commit -m "fix(notifications): resolve Notifiable routes from notification_channels config"
+```
+
+---
+
+## Task 3: Fix `DiscordMessage::toArray()` serialization bugs
+
+Three bugs in [src/Notifications/Channels/Discord/DiscordMessage.php:114-135](../../src/Notifications/Channels/Discord/DiscordMessage.php#L114): (a) `hexdec($this->color)` when `$color` is `null` (no color method called), (b) `icon_url` reads `$this->footerImg`, a property that does not exist (it is `$this->footerUrl`), so the footer icon is always blank, (c) `timestamp ?? now()` emits a `Carbon` object instead of an ISO-8601 string.
+
+**Files:**
+- Modify: `src/Notifications/Channels/Discord/DiscordMessage.php` (add a default color constant; fix `toArray()`)
+- Test: `tests/Unit/Notifications/Channels/Discord/DiscordMessageTest.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+
+namespace OzanKurt\Shield\Tests\Unit\Notifications\Channels\Discord;
+
+use OzanKurt\Shield\Notifications\Channels\Discord\DiscordMessage;
+use OzanKurt\Shield\Tests\TestCase;
+
+class DiscordMessageTest extends TestCase
+{
+    public function test_to_array_is_safe_without_a_color_method(): void
+    {
+        $embed = (new DiscordMessage)->title('Test')->toArray()['embeds'][0];
+
+        // Default gray color, not hexdec(null).
+        $this->assertSame(hexdec(DiscordMessage::COLOR_DEFAULT), $embed['color']);
+    }
+
+    public function test_footer_icon_uses_the_footer_url(): void
+    {
+        $embed = (new DiscordMessage)
+            ->footer('Shield', 'https://example.com/icon.png')
+            ->toArray()['embeds'][0];
+
+        $this->assertSame('https://example.com/icon.png', $embed['footer']['icon_url']);
+    }
+
+    public function test_timestamp_defaults_to_an_iso8601_string(): void
+    {
+        $embed = (new DiscordMessage)->title('Test')->toArray()['embeds'][0];
+
+        $this->assertIsString($embed['timestamp']);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `vendor/bin/phpunit --filter DiscordMessageTest`
+Expected: FAIL. `test_footer_icon_uses_the_footer_url` fails (icon_url is `''` because `footerImg` is undefined), `test_timestamp_defaults_to_an_iso8601_string` fails (value is a Carbon instance), and `COLOR_DEFAULT` does not exist yet (the color test errors).
+
+- [ ] **Step 3: Add the default color constant**
+
+In `src/Notifications/Channels/Discord/DiscordMessage.php`, add alongside the existing color constants (after `COLOR_ERROR`):
+
+```php
+    public const COLOR_DEFAULT = '6c757d'; // gray, used when no severity color is set
+```
+
+- [ ] **Step 4: Fix `toArray()`**
+
+Replace the `toArray()` method body:
+
+```php
+    public function toArray(): array
+    {
+        return [
+            'username' => $this->username,
+            'avatar_url' => $this->avatarUrl,
+            'embeds' => [
+                [
+                    'title' => $this->title,
+                    'url' => $this->url,
+                    'type' => 'rich',
+                    'description' => $this->description,
+                    'fields' => $this->fields,
+                    'color' => hexdec($this->color ?? self::COLOR_DEFAULT),
+                    'footer' => [
+                        'text' => $this->footer ?? '',
+                        'icon_url' => $this->footerUrl ?? '',
+                    ],
+                    'timestamp' => $this->timestamp ?? now()->toIso8601String(),
+                ],
+            ],
+        ];
+    }
+```
+
+(Changes: `username` no longer falls back to the stale `'Laravel Backup'` literal, the typed property is always set; `color` defaults to `COLOR_DEFAULT`; `icon_url` reads `footerUrl`; `timestamp` defaults to an ISO-8601 string.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `vendor/bin/phpunit --filter DiscordMessageTest`
+Expected: PASS (all three).
+
+- [ ] **Step 6: Run the full suite to confirm no regressions**
+
+Run: `vendor/bin/phpunit`
+Expected: no new failures introduced by these changes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Notifications/Channels/Discord/DiscordMessage.php tests/Unit/Notifications/Channels/Discord/DiscordMessageTest.php
+git commit -m "fix(notifications): correct DiscordMessage color, footer icon, and timestamp serialization"
+```
+
+---
+
+## Self-review
+
+- **Spec coverage:** Covers spec-005 Section 9 items that the integrity card depends on: Slack dependency (Task 1), `Notifiable` config paths (Task 2), `DiscordMessage` bugs (Task 3). The Section 9 `via()`/`viaQueues()` repairs of the existing login/attack notifications are intentionally deferred (see "Out of scope") because the integrity notification ships its own correct `via()` in a later plan; this is recorded, not dropped.
+- **Placeholder scan:** No TBD/TODO; every code step shows full code; every run step states the expected result.
+- **Type consistency:** `COLOR_DEFAULT` is referenced in the test and defined in Step 3 before use in Step 4. Config keys (`notification_channels.mail.to`, `.slack.to`, `.discord.webhook_url`) match [config/shield.php:110-141](../../config/shield.php#L110).
+
+## Remaining Phase 1 plans (roadmap, written next, not part of this plan's tasks)
+
+1. **Data layer** - `ls_integrity_{runs,changes,baselines}` migrations + models + dedicated lookups (`ls_integrity_statuses`, `ls_integrity_change_types`, `ls_integrity_comparison_bases`) + seeding + new `ScannerTrigger` names. (spec sections 5, 5.2, 5.3)
+2. **Engine** - `Manifest` (disk-aware streaming hash, incremental, canonical key, symlink/limit rules) + `Baseline` (signed artifact, scope fingerprint, atomic write, tamper vs corruption) + `IntegrityScanner` (lock, streaming diff, classify, chunked persist) + `WatchCommand` refactor onto `Manifest->hashes()` with the regression test. (spec sections 4, 6)
+3. **Notification + commands** - `IntegrityScanCompletedEvent`/`Listener`/`Notification` (correct `via()`, bounded queries, per-channel limits, `SeverityColor`, translations), feature-local throttle + suppression rules, `shield:integrity`/`-bless`/`-status`/`-prune`/heartbeat commands, scheduler wiring. (spec sections 6.4-6.8, 7, 8.1-8.3)
+4. **Dashboard + config + docs** - `IntegrityController` + routes + Bootstrap/DataTables views + the `integrity` config block + `notifications.integrity_changed` + `docs/integrity.md` + premium-gating note. (spec sections 8.4, 10, 11, 12)

--- a/docs/premium.md
+++ b/docs/premium.md
@@ -4,18 +4,18 @@ Premium features ship in the **same package** as free features. There's no separ
 
 ## What premium unlocks
 
-- **Real-time threat feed sync** — free tier syncs daily; premium polls every few minutes
-- **Real-time IP blocklist subscription** — same idea for blocklists
-- **Real-time malware signatures** — served by the Central app: premium hits `/api/signatures/premium` (fresh, gated server-side on `premium_signatures`, authorized with your license bearer); free hits the public `/api/signatures/free` lagging ~30 days (matches Wordfence's free-tier signature delay). Resolved per-run via `premium_signatures`; the channel is recorded in the `threat_feed.sync_completed` audit meta
-- **Hosted audit-log sink** — forward audit events to the Shield Central app for cross-site SIEM aggregation
-- **Future SIEM dashboard integration** — first-class consumer of the webhook channel
+- **Real-time threat feed sync**, free tier syncs daily; premium polls every few minutes
+- **Real-time IP blocklist subscription**, same idea for blocklists
+- **Real-time malware signatures**, served by the Central app: premium hits `/api/signatures/premium` (fresh, gated server-side on `premium_signatures`, authorized with your license bearer); free hits the public `/api/signatures/free` lagging ~30 days (matches Wordfence's free-tier signature delay). Resolved per-run via `premium_signatures`; the channel is recorded in the `threat_feed.sync_completed` audit meta
+- **Hosted audit-log sink**, forward audit events to the Shield Central app for cross-site SIEM aggregation
+- **Future SIEM dashboard integration**, first-class consumer of the webhook channel
 
-Local-only features (dashboard polish, advanced report templates, extra middlewares) are NOT premium-gated — those ship for everyone in the free release.
+Local-only features (dashboard polish, advanced report templates, extra middlewares) are NOT premium-gated, those ship for everyone in the free release.
 
 ## Setup
 
 1. Buy a license at [laravel-shield.ozankurt.com](https://laravel-shield.ozankurt.com)
-2. Receive your key — `ls-prem-xxxxxxxxxxxx`
+2. Receive your key, `ls-prem-xxxxxxxxxxxx`
 3. Add to `.env`:
 
 ```env
@@ -39,9 +39,9 @@ If the license API is unreachable for >24h, premium stays active for an addition
 
 This prevents an outage on Ozan's side from killing buyer sites.
 
-## Honest threat model — soft enforcement, not DRM
+## Honest threat model, soft enforcement, not DRM
 
-The local `LicenseChecker::isFeatureAvailable()` check is **patchable**. Any buyer can open `vendor/ozankurt/laravel-shield/src/Premium/LicenseChecker.php` and change `isFeatureAvailable()` to always return true. This is true for every open-source-distributed premium plugin — Wordfence, Yoast, ACF Pro, EDD, etc.
+The local `LicenseChecker::isFeatureAvailable()` check is **patchable**. Any buyer can open `vendor/ozankurt/laravel-shield/src/Premium/LicenseChecker.php` and change `isFeatureAvailable()` to always return true. This is true for every open-source-distributed premium plugin, Wordfence, Yoast, ACF Pro, EDD, etc.
 
 The license check is NOT designed to defeat crackers. It's designed to:
 - Give honest buyers a clean "license expired, please renew" UI signal
@@ -55,21 +55,21 @@ The real premium *value* lives server-side:
 
 | Premium feature | Where the value lives | Crack-able locally? |
 |---|---|---|
-| Real-time threat feed | `laravel-shield.ozankurt.com` API gates feed access by license key | No — patcher gets stale free signatures |
+| Real-time threat feed | `laravel-shield.ozankurt.com` API gates feed access by license key | No, patcher gets stale free signatures |
 | Real-time IP blocklist | Same API | No |
 | Hosted audit-log sink | Hosted ingestion endpoint | No |
 | SIEM dashboard | The Shield Central app | No |
 
 Patching `isFeatureAvailable()` doesn't unlock the API. The API still demands a valid key. Without one, the patched plugin works the same as the free package.
 
-**We do NOT implement:** encrypted code blobs (IonCube / SourceGuardian), Composer post-install validators, runtime file checksums. These hurt honest buyers and don't defeat crackers — not worth it.
+**We do NOT implement:** encrypted code blobs (IonCube / SourceGuardian), Composer post-install validators, runtime file checksums. These hurt honest buyers and don't defeat crackers, not worth it.
 
 ## Anti-abuse
 
 - API knows `site_url` per check → same key from many sites is visible to Ozan
 - `domain_limit` enforced API-side (returns `domain_limit_exceeded` past N domains)
 - Revocation is immediate (cached up to 24h on buyer side)
-- License key is treated as a secret — never logged, redacted via the standard sensitive-field redaction list
+- License key is treated as a secret, never logged, redacted via the standard sensitive-field redaction list
 
 ## Configuration
 

--- a/docs/reports.md
+++ b/docs/reports.md
@@ -60,7 +60,7 @@ Each cadence builds a uniform payload via `CadenceReportGenerator::build($cadenc
 ]
 ```
 
-Sections can be toggled on/off per-cadence via `shield.reports.<cadence>.sections` (planned — currently all sections render if data exists).
+Sections can be toggled on/off per-cadence via `shield.reports.<cadence>.sections` (planned, currently all sections render if data exists).
 
 ## Wordfence-style executive email
 
@@ -136,7 +136,7 @@ Reports are scheduled summaries. **Individual attack events** route through the 
     'critical' => ['mail', 'discord', 'webhook'],
     'high'     => ['mail', 'slack'],
     'medium'   => ['slack'],
-    'low'      => [],     // digest only — rolled into the daily_digest cadence
+    'low'      => [],     // digest only, rolled into the daily_digest cadence
 ],
 ```
 
@@ -177,7 +177,7 @@ The webhook channel emits a versioned JSON payload designed for consumption by t
   "links": {
     "dashboard": "https://your-app.com/shield"
   },
-  "data": { /* full payload — same shape as shield:report-test output */ }
+  "data": { /* full payload, same shape as shield:report-test output */ }
 }
 ```
 
@@ -185,7 +185,7 @@ The webhook channel emits a versioned JSON payload designed for consumption by t
 
 ## Telegram channel quirks
 
-Telegram messages have a 4096-character body limit. Long reports get truncated with a "[…N more]" suffix. For full reports, use mail or webhook channels — Telegram is best for high-severity individual events.
+Telegram messages have a 4096-character body limit. Long reports get truncated with a "[…N more]" suffix. For full reports, use mail or webhook channels, Telegram is best for high-severity individual events.
 
 ## Testing your report template
 
@@ -204,6 +204,6 @@ Combine with Mailtrap or `MAIL_MAILER=log` to preview the rendered HTML without 
 | Symptom | Cause | Fix |
 |---|---|---|
 | Scheduled report doesn't fire | Laravel scheduler not running | Add `* * * * * cd /path && php artisan schedule:run >> /dev/null 2>&1` to crontab |
-| Report email is empty | Window had 0 events | Expected — no email is sent when all sections are empty unless `shield.reports.<cadence>.send_when_empty` is true |
+| Report email is empty | Window had 0 events | Expected, no email is sent when all sections are empty unless `shield.reports.<cadence>.send_when_empty` is true |
 | Recipients receive duplicate reports | Multiple cron entries OR Horizon retrying a failed dispatch | Check `php artisan schedule:list` for duplicates; check `failed_jobs` table for retried sends |
 | Webhook payload missing `data` section | Payload schema_version mismatch with consumer | Consumer needs to handle `schema_version >= 1.0` flexibly; do not require unknown fields |

--- a/docs/scanner.md
+++ b/docs/scanner.md
@@ -45,11 +45,11 @@ php artisan shield:scan-cancel <run-id>
 php artisan shield:scan-status
 ```
 
-Or from the dashboard at `/shield/scanner` — "Start scan" button.
+Or from the dashboard at `/shield/scanner`, "Start scan" button.
 
 ## Signatures
 
-Built-in baseline (~33 patterns) is seeded on install — covers classic webshells (c99, r57, WSO, b374k, AlfaShell, p0wny, IndoXploit, FilesMan), eval/assert/preg_replace obfuscation chains, exec on superglobals, file_put_contents with chr() chains, etc.
+Built-in baseline (~33 patterns) is seeded on install, covers classic webshells (c99, r57, WSO, b374k, AlfaShell, p0wny, IndoXploit, FilesMan), eval/assert/preg_replace obfuscation chains, exec on superglobals, file_put_contents with chr() chains, etc.
 
 Sync from the hosted feed:
 
@@ -57,15 +57,15 @@ Sync from the hosted feed:
 php artisan shield:signatures-sync
 ```
 
-Falls back to the embedded baseline when the remote (GitHub Releases on `OzanKurt/laravel-shield-signatures`) is unreachable. Idempotent — upserts by `(source, source_ref)` and bumps `version`.
+Falls back to the embedded baseline when the remote (GitHub Releases on `OzanKurt/laravel-shield-signatures`) is unreachable. Idempotent, upserts by `(source, source_ref)` and bumps `version`.
 
 Pin to a specific tag via `LS_SIGNATURE_PIN=v2026.05` in `.env`.
 
 ## Quarantine
 
 Per-target policy controls what happens on a finding:
-- `move_and_stub` — moves the file to `storage/shield/quarantine/<uuid>.bin`, writes sidecar metadata JSON, leaves an empty stub at the original path
-- `log_only` — never touches the file; just records the finding
+- `move_and_stub`, moves the file to `storage/shield/quarantine/<uuid>.bin`, writes sidecar metadata JSON, leaves an empty stub at the original path
+- `log_only`, never touches the file; just records the finding
 
 Restore from CLI or dashboard:
 

--- a/docs/security-watch.md
+++ b/docs/security-watch.md
@@ -1,4 +1,4 @@
-# `shield:watch` — Continuous File Change Monitor
+# `shield:watch`, Continuous File Change Monitor
 
 `shield:watch` runs as a long-running process that detects file changes in real time (when `spatie/file-system-watcher` is installed) or via a polling loop (fallback for shared hosts without Node.js / chokidar).
 
@@ -21,7 +21,7 @@ echo "LS_WATCH_ENABLED=true" >> .env
 #       ],
 #   ],
 
-# Optional — install spatie/file-system-watcher for chokidar-backed mode
+# Optional, install spatie/file-system-watcher for chokidar-backed mode
 composer require spatie/file-system-watcher
 npm install chokidar
 

--- a/docs/specs/spec-005-file-integrity-scan-notification.md
+++ b/docs/specs/spec-005-file-integrity-scan-notification.md
@@ -1,0 +1,528 @@
+# Spec 005: File integrity scan + summary notification
+
+- Status: Draft
+- Track: Core (file integrity monitoring). New track, separate from the 001-004 premium-parity specs.
+- Tier: Baseline scanning is FREE. Only real-time integrity monitoring is premium (deferred to a later phase).
+- Premium feature flag (later phase): `integrity_realtime`
+
+This spec reproduces the "file integrity scan summary" notification (the Axel-bot
+screenshot: "N new / N modified / N deleted / N files total" with the changed paths
+grouped by type, posted to Discord/Slack/email) as a first-class, secure, scalable
+feature of `ozankurt/laravel-shield`.
+
+It was hardened by a multi-agent review pass (codebase mapping + 5 adversarial lenses:
+security, integration, scale, edge-cases, notification fidelity). The non-obvious
+findings from that pass are baked into the design below and called out where they
+overturned the naive approach.
+
+---
+
+## 1. Problem / current state
+
+The package can detect malware (signature scanner) and watch files in real time
+(`shield:watch`), but it has no "diff the filesystem against an approved baseline and
+send one grouped summary" capability. The closest pieces today:
+
+- `shield:watch` ([src/Console/Commands/WatchCommand.php](../../src/Console/Commands/WatchCommand.php)) keeps an in-memory `path => sha256` baseline and emits **per-file** `created`/`updated`/`deleted` events. It is a long-running process, not a periodic summary, and the baseline is lost on restart.
+- The `config_drift` scanner target does checksums-vs-baseline but only for `config/*.php`.
+- `ScannerRun` / `ScannerFinding` model malware findings, not integrity deltas.
+
+So the exact thing in the screenshot, a scheduled batch that snapshots the whole file
+set, diffs it, and posts a single digest, does not exist.
+
+### 1.1 Prerequisite reality check (these blocked the naive design)
+
+The naive plan assumed infrastructure that is **not in the codebase**. Confirmed against source:
+
+1. **No routing matrix, no throttle.** `docs/notifications.md` documents a severity routing matrix and a throttle, but `config/shield.php` has only `notifications` (event toggles) and `notification_channels` (delivery). `via()` enables a channel purely on its `enabled` flag. There is no severity routing and no coalescing anywhere. This spec must NOT claim them as existing infra; it ships a flat per-event config plus a small feature-local throttle.
+2. **Slack channel is not installed.** `composer.json` declares no Slack channel and `vendor/laravel/` contains only `framework`, `prompts`, `serializable-closure`, `tinker`. `Illuminate\Notifications\Messages\SlackMessage` is not guaranteed present on Laravel 10-12 (it was extracted to `laravel/slack-notification-channel`). The existing `toSlack()` methods would fatal the moment Slack is an active channel.
+3. **`Notifiable` reads the wrong config paths.** [src/Notifications/Notifiable.php](../../src/Notifications/Notifiable.php) reads `config('shield.notifications.mail.to')` / `...slack.to` / `...discord.webhook_url`, but delivery settings live under `config('shield.notification_channels.*')`. Mail/Slack `to` resolve to `null` today.
+4. **`DiscordMessage::toArray()` bugs** ([src/Notifications/Channels/Discord/DiscordMessage.php:114-135](../../src/Notifications/Channels/Discord/DiscordMessage.php#L114)): `hexdec($this->color)` with a nullable `$color` default (TypeError when no color method was called), reads an undefined `$this->footerImg` (should be `$this->footerUrl`, so the footer icon never renders), and `timestamp ?? now()` emits a Carbon object instead of an ISO-8601 string.
+5. **`via()`/`viaQueues()` are buggy** in `AttackDetectedNotification` (iterates event keys as if they were channel names), and `FailedLoginNotification` / `SuccessfulLoginNotification` have a literal `$this->$this->config` typo. These must NOT be copied as the template.
+
+Section 9 fixes 1-5 as in-scope prerequisites with regression tests, because the new
+notification depends on every one of them working.
+
+---
+
+## 2. Goal
+
+A scheduled (and on-demand) **file integrity scan** that:
+
+1. Snapshots a manifest of file hashes for a configured Laravel filesystem disk.
+2. Diffs the current state against a **pinned known-good baseline** AND against the **previous run** (hybrid model).
+3. Persists a run + per-file changes for the dashboard.
+4. Sends one grouped **summary notification** (mail / Slack / Discord) that looks like the screenshot, leading with the per-run delta and carrying a known-good drift indicator.
+5. Is **safe by default on an already-compromised host** and **viable at ~92,000 files**, including the cPanel/FTP docroot scenario in the screenshot.
+
+---
+
+## 3. Non-goals (Phase 1)
+
+- **Remote disks (sftp/s3) as a first-class, tuned path.** The engine is disk-abstraction-based so a remote disk *works*, but the S3 ETag pre-filter, partial-read failure budget, and cleartext-FTP warnings are Phase 2. Phase 1 targets the local disk (including a docroot outside `base_path()`).
+- **Premium real-time integrity** (reuse the watcher, gated by `integrity_realtime`). Phase 2.
+- **Off-box authority** (Central attestation of the baseline root hash, critical-alert decisioning, two-person bless, dead-man's-switch). Phase 3. Phase 1 keeps a *local* heartbeat + dashboard banner and stores the root hash in DB + the HMAC audit chain so Phase 3 can slot in.
+- **Known-good cross-check against `composer.lock` dist hashes / framework manifests.** Strongly desired (it is the only real "good" reference on a fresh-but-infected host) but heavy; Phase 2. Phase 1 mitigates with the provisional-first-run posture (Section 6.1).
+- Building the documented severity routing matrix as a general framework. This spec ships only what the integrity card needs.
+
+---
+
+## 4. Architecture
+
+New module `src/Services/Integrity/` with three single-purpose units.
+
+### 4.1 `Manifest` (the shared hasher)
+
+Given a disk + scan spec (include/exclude globs, `follow_symlinks`, `max_file_size`,
+`hash_algo`), walks files and produces an **ordered** (sorted by path) list of entries:
+
+```
+{ path, sha256|null, size, mtime, kind }   // kind: hashed | size_only | symlink | unreadable
+```
+
+Rules that the review made non-negotiable:
+
+- **Canonical key** = disk-relative POSIX path (forward slashes), one normalized form. This is the single key shared with the refactored `shield:watch` baseline so path formats never drift between runs or between watch and integrity.
+- **Disk-aware streaming hash.** Laravel `Storage` has no streaming-hash primitive. Local disks use a fast path (`hash_file` on the absolute path). Non-local disks use `hash_init` + `Storage::readStream` + chunked `hash_update` (never `Storage::get`, which loads the whole file into memory).
+- **Incremental.** Accepts the prior (known-good) manifest. A file whose `size` AND `mtime` both match the baseline is carried forward as unchanged WITHOUT re-hashing. Only new files and size/mtime-changed files are hashed. This is the single biggest scale win and is mandatory at 92k files. A configurable `full_rehash_cron` forces a periodic content re-verification (defends against an attacker who preserves size+mtime; see 6.5).
+- **Symlinks not followed by default.** A symlink is recorded as its own entry (`kind=symlink`, with target) so a newly appeared symlink is itself a change, even though its target is not hashed. A resolved path that escapes the disk root (traversal) is flagged, not hashed.
+- **Always hash script extensions** (`.php .phtml .phar .phps .inc` etc.) regardless of `max_file_size`. The oversized-skip-hash optimization must never apply to executable content (anti-evasion).
+- **Iteration caps** carried over from the existing `DirectoryIterator` (`max_files`, `max_iterations`, symlink-loop protection). Exceeding a cap aborts the run with `status=aborted_limit` + an ops signal, never a silent truncation.
+- **`->hashes(): array<path,sha256>` view** for back-compat: `WatchCommand::scanPaths()` delegates to `Manifest` but consumes this flat view, preserving its exact string-hash compare. Watch currently keys on **absolute OS paths**; the back-compat view returns those same absolute-path keys for the watch use case, so watch's `file.drift` audit-log path format is unchanged. The integrity engine uses canonical disk-relative POSIX keys internally. A regression test asserts identical created/updated/deleted output before and after the refactor.
+
+### 4.2 `Baseline` (pinned known-good)
+
+- Stored as a **sorted gzipped NDJSON artifact** with a header recording the **scope fingerprint** (disk, include, exclude, follow_symlinks, max_file_size, hash_algo) and the **root hash** (a hash over the sorted manifest). Default path `storage/shield/integrity/<disk>/baseline.ndjson.gz`; `storage/` is in the default exclude set so the artifact is never self-scanned.
+- **HMAC-signed**, with honest limits documented:
+  - Signing key resolves from `integrity.baseline.hmac_key_path` (a file `chmod 600` **outside** the scan root) and falls back to `LS_INTEGRITY_HMAC_KEY`. The spec states plainly that any same-host key is readable by an attacker who already has file write; HMAC defends against an unprivileged process that can write `storage/` but not read the key, and against accidental corruption. Real authority is Phase 3 (off-box).
+  - **Hard-fail (refuse to sign/run, raise an alert)** if the resolved secret is empty or equals the audit-log dev fallback constant. No silent signing with a public constant.
+  - Domain separation: the HMAC payload is prefixed with `shield.integrity.baseline.v1`, distinct from the audit chain.
+  - Recursive canonical serialization before HMAC (sorted NDJSON is already canonical).
+- **Root hash is mirrored into `ls_integrity_baselines` (DB) and the HMAC-chained audit log**, so hiding a tamper requires forging the artifact, the DB row, and the audit chain.
+- **Atomic write** (tmp file + rename). The active-baseline pointer (`ls_integrity_baselines`) flips inside a DB transaction only after the artifact is fully written and re-verified.
+- **HMAC verify failure on an existing artifact = security event** (`tamper_suspected`): the run records that status, fires a high/critical security signal, and does NOT auto-rebless. A **missing** artifact is the first-run path (provisional, Section 6.1). A truncated/unparseable artifact fails the run and requires an explicit re-bless. The design never silently rebuilds the baseline on a verification failure.
+
+### 4.3 `IntegrityScanner` (orchestrator)
+
+Per run:
+
+1. Acquire a per-disk `Cache::lock("shield:integrity:{disk}", ttl=max_runtime)`. Require an atomic-lock-capable cache store (redis/memcached/database); fail loud if the store is `array`. If the lock is held, record `status=skipped` and exit 0 (do not pile up). If skipped for N consecutive intervals, escalate (heartbeat, 6.4).
+2. Load + HMAC-verify the known-good baseline. Compare its scope fingerprint to the current run's spec; on mismatch, either refuse and require re-bless, or diff over the scope intersection and label entrants/leavers as `scope_changed` (a non-alarming change type), never as new/deleted. The scope intersection is the set of paths that match include-and-not-exclude under the roots in BOTH the baseline spec and the current spec; a path in-scope under only one spec is `scope_changed`.
+3. Build the current manifest incrementally (4.1).
+4. **Streaming merge-join diff** over sorted manifests vs known-good AND vs the previous run's stored manifest. Peak memory is O(1) in file count, not O(n): never hold three full 92k maps simultaneously.
+5. Classify each change: `new | modified | deleted | scope_changed | became_unreadable | vanished | volatile | symlink_new`. A file that vanished mid-scan is dropped. A tracked file that became unreadable is `became_unreadable` (medium), never "deleted" and never "unchanged"; its last-known hash is carried with a stale flag. A file whose mtime/size changed again right after hashing is `volatile` and excluded from severity escalation.
+6. Compute per-change severity (6.5) and run severity. Alarm/paging severity derives from the **per-run delta**; a critical **known-good drift** path can still escalate the card and is always listed explicitly (no slow-drip hiding).
+7. Persist the run + changes with **chunked `DB::table()->insert()`** in batches (~1000), carrying the hash from the manifest (no re-hash in the persist loop), capped at `max_persisted_changes_per_run` with a "truncated, N more" marker.
+8. Write the current manifest as the run artifact (for the next run's previous-run diff).
+9. Honor a `max_runtime` budget: on exceed, finish as `status=timed_out` recording files processed.
+10. Fire `IntegrityScanCompletedEvent($run)`; release the lock.
+
+`shield:integrity-bless` **promotes the most recent successful run's manifest** to known-good (it does not re-walk the disk), writes atomically, takes the per-disk lock, is audited (actor + diff summary + old/new root hash), and is idempotent by content hash.
+
+---
+
+## 5. Data model
+
+Conventions (from `src/Support/Migrations/ShieldBlueprint.php`, `src/Concerns/*`,
+`src/Models/Lookups/Lookup.php`): data tables get `id` + `uuid` (uuid7) + optional
+`correlation_id` + userstamps + softDeletes + timestamps via `ShieldBlueprint::applyStandard()`;
+lookup tables get only `id/name/label/description/sort_order/meta/timestamps`; FK columns
+are `unsignedBigInteger` + indexed + explicit `foreign()`; **no enums, int FK to seeded
+lookups**; connection set from `config('shield.database.connection')`; lookups created
+in a migration BEFORE the data tables that reference them.
+
+### 5.1 Data tables
+
+`ls_integrity_runs`:
+
+| column | notes |
+|---|---|
+| `status_id` | FK `ls_integrity_statuses` |
+| `trigger_id` | FK `ls_scanner_triggers` (reused; new names seeded) |
+| `severity_id` | FK `ls_log_levels` (reused; same lookup `ScannerFinding.severity_id` uses) |
+| `disk` | string |
+| `scope_fingerprint` | hash of the effective scan spec |
+| `baseline_root_hash`, `current_root_hash` | string |
+| `files_total`, `files_hashed`, `files_size_only`, `files_unreadable`, `files_excluded` | int counters (5.4) |
+| `count_new`, `count_modified`, `count_deleted`, `count_scope_changed`, `count_vs_known_good` | int |
+| `started_at`, `finished_at`, `duration_ms`, `error_message` | |
+| + `applyCorrelationId()` + `applyStandard()` | |
+
+`ls_integrity_changes` (high volume):
+
+| column | notes |
+|---|---|
+| `integrity_run_id` | FK `ls_integrity_runs` |
+| `change_type_id` | FK `ls_integrity_change_types` |
+| `compared_to_id` | FK `ls_integrity_comparison_bases` (NOT a string enum) |
+| `severity_id` | FK `ls_log_levels` |
+| `path` | string, indexed |
+| `old_hash`, `new_hash`, `size_bytes`, `file_mtime`, `symlink_target` | |
+| + `applyCorrelationId()` + `applyStandard()` | keeps the house uuid7/userstamps/softDeletes convention |
+
+> Volume note: keeping softDeletes on a derived, regenerable, high-volume table is a
+> deliberate consistency choice (the package's hard rule is "every table gets
+> uuid7+userstamps+softdeletes"). It is mitigated by `max_persisted_changes_per_run`
+> and a `shield:integrity-prune` command that **force-deletes** (bypasses softDelete)
+> rows older than `retention.changes_days`. The notification never hydrates this table
+> (5.5).
+
+`ls_integrity_baselines`:
+
+| column | notes |
+|---|---|
+| `disk`, `scope_fingerprint`, `root_hash`, `artifact_path`, `algo` | |
+| `files_total`, `signed` (bool), `blessed_at` | |
+| + `applyStandard()` | `blessed_by` comes from the userstamp `created_by_id` |
+
+One active baseline per disk (older ones soft-deleted).
+
+### 5.2 New lookup tables (dedicated, per the convention rec)
+
+- `ls_integrity_statuses`: `running, completed, failed, baseline_established, tamper_suspected, incomplete, timed_out, skipped, aborted_limit, cancelled`.
+- `ls_integrity_change_types`: `new, modified, deleted, scope_changed, became_unreadable, vanished, volatile, symlink_new`.
+- `ls_integrity_comparison_bases`: `last_run, known_good`.
+
+### 5.3 Lookup seeding
+
+Add `seedIntegrityStatuses()`, `seedIntegrityChangeTypes()`, `seedIntegrityComparisonBases()`
+to `database/seeders/LookupTableSeeder.php` (same `updateOrCreate(['name'=>...])` loop as
+`seedScannerStatuses()`), called from `run()`. Add the new `ScannerTrigger` names
+(`integrity_scheduled, integrity_manual, integrity_dashboard, integrity_watch`) to
+`seedScannerTriggers()`. After seeding new lookups at runtime, `LookupResolver::flush()`
+the affected classes.
+
+### 5.4 `files_total` definition (stability matters)
+
+`files_total` = distinct in-scope paths **present** at enumeration, whether hashed,
+size-only, or unreadable. A file that is present-but-unreadable is still counted (it
+exists), not dropped; only paths that are **absent** now are excluded from `files_total`.
+Reported alongside `files_hashed`, `files_size_only`, `files_unreadable`,
+`files_excluded`. `count_*` is computed over the hashed + size-only set. A tracked file
+that is present but unreadable is classified `became_unreadable` and counted in
+`files_unreadable`, never as `deleted`; this keeps `files_total` stable run-to-run when a
+file is transiently locked. The card renders `files_total` identically to the dashboard.
+
+### 5.5 Models
+
+`IntegrityRun`, `IntegrityChange`, `IntegrityBaseline` follow the `ScannerRun` pattern
+(`HasUuid, HasUserstamps, SoftDeletes`, connection in `__construct`, `belongsTo` lookups,
+`hasMany` changes). Lookup models (`IntegrityStatus`, `IntegrityChangeType`,
+`IntegrityComparisonBasis`) extend `Lookup` with just `$table`.
+
+---
+
+## 6. Security model (the part that makes it a real control)
+
+### 6.1 No silent auto-bless on first run (default `auto_bless_on_first_run = false`)
+
+FIM is often installed onto an already-compromised host, so trusting "whatever is on
+disk at install" certifies the webshell as good forever. First run therefore:
+
+- Establishes a **provisional** baseline (`status=baseline_established`), marked unverified.
+- Sends a loud, non-suppressible "baseline established from N files, NOT independently verified, review before trusting" notice that **lists executable/script files found in web-reachable paths** at bless time, applying the critical severity heuristic.
+- Requires an explicit `shield:integrity-bless --confirm` (or the dashboard button) to promote provisional to trusted.
+- Phase 2 adds the `composer.lock` dist-hash / framework cross-check so `vendor/` and framework files get a real external "good" reference on first run.
+
+### 6.2 Bless is an audited, attributable, permission-gated action
+
+Every bless writes an HMAC-chained audit entry: actor, the diff being blessed, old/new
+root hash. The dashboard button is gated behind a dedicated permission, not generic
+dashboard access. Blessing the same content twice is a no-op.
+
+### 6.3 Self-protection scope (non-excludable targets)
+
+`config/shield.php`, the package service provider, the host scheduler entrypoint
+(`app/Console/Kernel.php`, or `bootstrap/app.php` on Laravel 11+), the package's own
+`src/`, and the baseline/key artifacts are always-tracked and cannot be excluded.
+Enable/disable state transitions are written to the HMAC audit log.
+
+### 6.4 Local heartbeat / dead-man's-switch
+
+A scheduled check raises a high-severity dashboard banner + alert when there has been no
+successful integrity run in N schedule intervals, or when runs are repeatedly `skipped`
+(lock starvation) or `timed_out`. This converts "attacker disabled the scanner" and
+"silent stop on a leaked lock" into a positive signal. (`suppress_when_no_changes` makes
+silence ambiguous; the heartbeat removes that ambiguity.) Full off-box dead-man is Phase 3.
+
+### 6.5 Severity heuristic (ordered, first-match, configurable)
+
+Run severity = max over its changes. Drives the card color and the throttle decision.
+
+- **critical**: new/modified script-extension file under a web-reachable docroot (`public/`, `storage/app/public/`, the configured public docroot). This is the exact screenshot case (`footer.php`/`header.php` under a cache dir). This rule is **non-suppressible**: a script file may be excluded from NOISE but never from script-extension detection, and is critical even on the first run or right after a bless (a script not in the blessed set is suspicious by definition).
+- **high**: new/modified `.php` in `app/ routes/ config/`; deletion of any tracked file; change under `vendor/` (Phase 2 refines this to "differs from `composer.lock` dist hash" to kill deploy false-positives).
+- **medium**: `.env`/`.htaccess`/`.user.ini` change; `became_unreadable`; modified non-code in sensitive dirs.
+- **low**: everything else (e.g. the screenshot's `error_log` churn).
+
+### 6.6 Anti-evasion details
+
+- Schedule **jitter** (randomized offset) so the scan instant is not predictable (defeats minute-59 swap-back); the cron is not exposed externally.
+- Script-extension files always hashed (6.1 / 4.1), so size+mtime backdating cannot skip them.
+- mtime going backwards with differing content is flagged suspicious.
+- Abnormally large change set outside a maintenance window is itself a high-severity signal ("possible mass tampering / log-flood evasion"), not merely a truncated card.
+
+### 6.7 Information-disclosure containment
+
+- Secret-bearing files (`.env`, key files) are tracked by **existence + mtime only by default** (or HMAC, not bare sha256) so the stored value is not a guess-verification oracle and never lands on the wire.
+- Outbound notifications **redact sensitive paths** for those categories ("`.env` changed" without the tree), and external-channel path disclosure is opt-in with a clear warning. Default to "N changes, view in dashboard" over dumping a full path list to a third-party webhook.
+- The manifest artifact and webhook URLs are documented as secrets; the artifact reveals filesystem layout.
+
+### 6.8 Notifications cannot be silently suppressed or flooded around
+
+- Within each group, sort by **severity DESC then path**; a critical finding is NEVER pushed into "+N more" and forces the card to critical.
+- Critical-severity integrity changes **bypass the feature-local throttle** (the throttle is for low/medium noise).
+- Security-critical signals (`tamper_suspected`, baseline missing/corrupt, repeated remote failure, provisional first bless) **always** go to the audit log + Laravel log + a persistent dashboard banner, regardless of notification-channel config, and bypass `suppress_when_no_changes`.
+
+---
+
+## 7. Notification
+
+### 7.1 `IntegrityScanCompletedNotification`
+
+- `via()` reads the **event block** `config('shield.notifications.integrity_changed')` and iterates its `channels` array (NOT the broken `AttackDetectedNotification` pattern that iterates event keys). Channel delivery comes from `config('shield.notification_channels.<channel>')`.
+- Card is built from **bounded queries**: `WHERE integrity_run_id=? AND change_type_id=? ORDER BY severity DESC, path LIMIT (max_paths_per_group+1)` per group, plus persisted `count_*` for headers. The full change set is never hydrated (avoids OOM on a 20k-file deploy).
+- Header = **delta only**, labeled "Since last scan". A separate, muted "Vs approved baseline: N files differ (since `<blessed_at>`)" block carries the known-good drift. The two counts are never merged. Per-group "view all" deep-links to `compared_to=last_run`; the drift CTA links to `compared_to=known_good`.
+- Timestamp rendered with explicit `->setTimezone(config('shield.integrity.notify.timezone','UTC'))` so "(UTC)" is a conversion, not a mislabel. Paths shortened (strip `base_path()`).
+- Translations under `shield::notifications.integrity_changed.{mail,slack,discord}.*`: title, summary line, group headers, "+N more", drift line, and the `baseline_established` / `baseline_missing` / `all_clear` variants.
+
+### 7.2 Per-channel rendering + hard limits
+
+A shared `SeverityColor` helper maps `critical/high/medium/low/all_clear` to hex, reused
+by all three channels.
+
+- **Mail**: executive markdown theme like `SecurityReportNotification` (grouped tables + `mail::button` CTA to the run page).
+- **Discord**: `toDiscord()` with NO `$notifiable` param (matches `DiscordChannel::send`). Put group lists in the embed **description** (4096 limit) or budget field values under ~1000 chars; the single authoritative link goes in the embed **title url** (no per-field links). A validator enforces Discord limits before POST (field value <=1024, name/title <=256, description <=4096, <=10 fields, <=6000 embed total, <=2000 message, <=10 embeds) and truncates deterministically with a trailing "+N more -> dashboard", degrading to counts-only if even truncated lists overflow. Requires the `DiscordMessage` fixes in Section 9.
+- **Slack**: Block Kit (`laravel/slack-notification-channel` v3, added in Section 9). Groups as section blocks (mrkdwn), <=3000 chars/section, <=50 blocks, a `<url|View all>` link or actions block.
+
+### 7.3 `IntegrityScanCompletedListener` + feature-local throttle
+
+- Modeled on `AttackDetectedListener` (thin, **no** `ListenerHelper`: integrity runs in console with no HTTP request/auth-log context). Checks `config('shield.notifications.integrity_changed.enabled')`, then `(new Notifiable)->notify(new IntegrityScanCompletedNotification($run))` wrapped in `try/report()`.
+- Throttle: a `Cache` counter keyed by `disk + delta-severity + changeset-hash` over a window, emitting a "N similar runs suppressed" continuation line. Critical bypasses it (6.8).
+- `suppress_when_no_changes` suppresses ONLY when the per-run delta is empty AND there is no security event. Persistent known-good drift does not re-page hourly; instead a separate `notify.drift_reminder_cadence` (default daily, not hourly) nags until re-bless.
+- Registered in `ShieldServiceProvider::registerListeners()` via `$this->app['events']->listen(IntegrityScanCompletedEvent::class, IntegrityScanCompletedListener::class)`.
+
+---
+
+## 8. Commands, scheduling, dashboard, queue
+
+### 8.1 Commands (registered in `ShieldServiceProvider::registerCommands()`)
+
+- `shield:integrity {--disk=} {--trigger=integrity_manual} {--sync}` (run; `--sync` only for tiny sites/tests).
+- `shield:integrity-bless {--disk=} {--confirm}` (promote last run's manifest; audited; atomic).
+- `shield:integrity-status {--disk=}`.
+- `shield:integrity-prune` (retention; force-delete).
+
+### 8.2 Scheduling (config-driven, jittered)
+
+In the `booted()` callback, guarded by `config('shield.integrity.schedule.enabled')`:
+`->command('shield:integrity')->cron(config('shield.integrity.schedule.cron'))->withoutOverlapping($ttl)`
+plus a jitter offset. Cron read from config only (env default lives in `config/shield.php`,
+so `config:cache` bakes it). A separate heartbeat check (6.4) and the
+`full_rehash_cron` are wired the same way.
+
+### 8.3 Queue isolation
+
+The scan runs on a **dedicated queue** `config('shield.integrity.queue','shield-integrity')`,
+NOT `default` (which carries mail/slack notifications, so a long scan must not delay
+attack alerts). Job `$timeout >= max_runtime`, `$tries = 1` (a half-finished integrity
+scan must not silently retry and re-hammer the disk). The dashboard "Run now" button
+**dispatches a job and polls run status** (mirrors `ScannerController`); it is never
+synchronous over 92k files. Polling endpoint: `GET shield/integrity/runs/{uuid}?mode=status`
+returns JSON `{ status, count_new, count_modified, count_deleted, files_processed, finished_at }`;
+the page polls every few seconds until a terminal status (`completed`/`failed`/`timed_out`/`incomplete`).
+
+### 8.4 Dashboard
+
+`IntegrityController` (extends `App\Http\Controllers\Controller`), methods
+`index / runs / changes / scan / bless`, splitting on `request->get('mode')==='dataTable'`,
+returning the `{ actions: [ {type:'toastr'}, {type:'reloadDataTable', data:{dataTableId:'integrityRunsTable'}} ] }`
+envelope for POST actions. Routes added inside the existing `registerRoutes()` group
+(config-driven prefix + middleware, `name('integrity.*')`), gated by
+`config('shield.dashboard.enabled')`. Views under `resources/views/dashboard/integrity/`
+(`@extends('shield::layouts.bootstrap.app')`, Bootstrap 5 + DataTables.net, links via
+`app('shield')->route('shield.integrity.*')`). Surfaces: stats cards (last run, baseline
+age, delta, known-good drift), run history table, per-run changes drill-down filterable
+by type/severity, the provisional/tamper banners (6.1/6.4/4.2), "Bless current state" and
+"Run now" buttons.
+
+---
+
+## 9. Prerequisite fixes (in scope, with regression tests)
+
+These ship in the same PR because the integrity notification depends on them:
+
+| Fix | File |
+|---|---|
+| Add `laravel/slack-notification-channel: ^3.0`; standardize on Block Kit `SlackMessage`; fix the two existing broken `toSlack()` methods | `composer.json`, `AttackDetectedNotification`, `SecurityReportNotification` |
+| `Notifiable` reads `config('shield.notification_channels.{mail,slack,discord}.*')` | [src/Notifications/Notifiable.php](../../src/Notifications/Notifiable.php) |
+| `DiscordMessage::toArray()`: `footerImg`->`footerUrl`; null-safe color default (gray) so `hexdec` never gets null; `timestamp` -> `toIso8601String()` string; drop the `'Laravel Backup'` default | [src/Notifications/Channels/Discord/DiscordMessage.php](../../src/Notifications/Channels/Discord/DiscordMessage.php) |
+| Correct `via()`/`viaQueues()`: read the event block's `channels` and per-channel `queue` from `notification_channels`; fix `$this->$this->config` typos | `AttackDetectedNotification`, `FailedLoginNotification`, `SuccessfulLoginNotification`, `SecurityReportNotification` |
+
+The new `IntegrityScanCompletedNotification` is the **reference** for the correct `via()`;
+the existing classes are fixed to match it.
+
+---
+
+## 10. Config & env
+
+```php
+// config/shield.php
+
+'integrity' => [
+    'enabled' => env('LS_INTEGRITY_ENABLED', false),
+
+    'disks' => [
+        'app' => [
+            // Docroot-aware: scans base_path() AND the real public docroot even when
+            // it lives outside base_path() (cPanel/FTP layout from the screenshot).
+            'disk' => env('LS_INTEGRITY_DISK', 'local'),
+            'roots' => [base_path(), public_path()],
+            'include' => ['**/*'],
+            'exclude' => [
+                'vendor/**', 'node_modules/**', '.git/**',
+                'storage/framework/**', 'storage/logs/**', 'bootstrap/cache/**',
+                'storage/shield/**', // the baseline artifact lives here
+            ],
+            'follow_symlinks' => false,
+            'max_file_size' => 50 * 1024 * 1024, // size-only above this, EXCEPT script extensions
+        ],
+    ],
+
+    'hash_algo' => 'sha256',
+    'queue' => env('LS_INTEGRITY_QUEUE', 'shield-integrity'),
+
+    'schedule' => [
+        'enabled' => env('LS_INTEGRITY_SCHEDULE_ENABLED', true),
+        'cron' => env('LS_INTEGRITY_SCAN_CRON', '0 * * * *'), // hourly, jittered
+        'jitter_seconds' => 300,
+    ],
+    'full_rehash_cron' => env('LS_INTEGRITY_FULL_REHASH_CRON', '0 3 * * 0'), // weekly content re-verify
+
+    'baseline' => [
+        'auto_bless_on_first_run' => false, // see 6.1
+        'sign_artifact' => true,
+        'hmac_key_path' => env('LS_INTEGRITY_HMAC_KEY_PATH'), // file chmod 600 OUTSIDE scan root
+    ],
+
+    'limits' => [
+        'max_files' => 500000,
+        'max_iterations' => 1000000,
+        'max_runtime' => 3600,
+        'max_persisted_changes_per_run' => 5000,
+    ],
+
+    'notify' => [
+        'suppress_when_no_changes' => true,   // delta==0 AND no security event
+        'send_all_clear' => false,
+        'max_paths_per_group' => 15,
+        'timezone' => 'UTC',
+        'disclose_paths_to_external_channels' => false, // redact sensitive paths by default
+        'drift_reminder_cadence' => 'daily',
+        'throttle' => ['window' => 1800, 'max_per_window' => 1], // critical bypasses
+    ],
+
+    'retention' => [
+        'runs_days' => 90,
+        'changes_days' => 30,
+    ],
+
+    // Ordered, first match wins. Each rule matches on path glob(s), extensions,
+    // and/or change types, and assigns a severity. {public_docroot} expands to the
+    // resolved public web root. See 6.5.
+    'severity_rules' => [
+        ['when' => ['path_any' => ['public/**', 'storage/app/public/**', '{public_docroot}/**'], 'ext_any' => ['php', 'phtml', 'phar', 'phps', 'inc']], 'severity' => 'critical', 'non_suppressible' => true],
+        ['when' => ['change_type_any' => ['deleted']], 'severity' => 'high'],
+        ['when' => ['path_any' => ['app/**', 'routes/**', 'config/**'], 'ext_any' => ['php']], 'severity' => 'high'],
+        ['when' => ['path_any' => ['vendor/**']], 'severity' => 'high'], // Phase 2: refine to "differs from composer.lock dist hash"
+        ['when' => ['path_any' => ['.env', '.env.*', '**/.htaccess', '**/.user.ini']], 'severity' => 'medium'],
+        ['when' => ['change_type_any' => ['became_unreadable']], 'severity' => 'medium'],
+        ['when' => ['always' => true], 'severity' => 'low'], // default
+    ],
+],
+```
+
+```php
+// config/shield.php -> notifications (event toggle, consistent with siblings)
+'integrity_changed' => [
+    'enabled' => env('FIREWALL_NOTIFICATIONS_INTEGRITY_CHANGED_ENABLED', false),
+    'channels' => ['mail', 'discord'],
+],
+```
+
+> Env-prefix note: the engine block uses `LS_INTEGRITY_*` (matches the scanner era); the
+> notification **event toggle** uses `FIREWALL_NOTIFICATIONS_*` to stay consistent with
+> its siblings (`FIREWALL_NOTIFICATIONS_ATTACK_DETECTED_ENABLED`). Migrating the whole
+> notifications block to `LS_` is a separate cleanup, out of scope here.
+
+---
+
+## 11. Premium gating & free fallback
+
+- Baseline integrity scanning, the hybrid diff, the dashboard, and the summary notification are **FREE** (mirrors Wordfence's free file-integrity model).
+- **Phase 2** gates only real-time integrity monitoring via `Shield::isFeatureAvailable('integrity_realtime')`, independent of the free `shield.scanner.watch.enabled` toggle (do not overload that flag as the premium switch). Listed in `docs/premium.md` (anything not listed is free).
+- Premium paths degrade to free behavior when the license is missing/expired/unreachable, per the shared conventions in `docs/specs/README.md`.
+
+---
+
+## 12. Files to add / change
+
+**Add**
+
+- `src/Services/Integrity/{Manifest,Baseline,IntegrityScanner,SeverityColor}.php`
+- `src/Events/IntegrityScanCompletedEvent.php`
+- `src/Listeners/IntegrityScanCompletedListener.php`
+- `src/Notifications/IntegrityScanCompletedNotification.php`
+- `src/Console/Commands/{IntegrityScanCommand,IntegrityBlessCommand,IntegrityStatusCommand,IntegrityPruneCommand,IntegrityHeartbeatCommand}.php`
+- `src/Models/{IntegrityRun,IntegrityChange,IntegrityBaseline}.php`
+- `src/Models/Lookups/{IntegrityStatus,IntegrityChangeType,IntegrityComparisonBasis}.php`
+- `src/Http/Controllers/IntegrityController.php`
+- `database/migrations/*_create_ls_integrity_lookup_tables.php` (before data tables)
+- `database/migrations/*_create_ls_integrity_{runs,changes,baselines}_tables.php`
+- `resources/views/dashboard/integrity/{index,runs,changes}.blade.php`
+- `resources/lang/en/notifications.php` keys under `integrity_changed`
+- `docs/integrity.md`
+
+**Change**
+
+- `composer.json` (add `laravel/slack-notification-channel`)
+- `src/ShieldServiceProvider.php` (register commands, listener, routes, schedules, the `Manifest` singleton)
+- `src/Console/Commands/WatchCommand.php` (delegate `scanPaths()` to `Manifest->hashes()`)
+- `database/seeders/LookupTableSeeder.php` (seed new integrity lookups + new trigger names)
+- `config/shield.php` (the `integrity` block + `notifications.integrity_changed`)
+- Prerequisite fixes in Section 9
+- `docs/notifications.md` (mark routing/throttle as planned, not shipped)
+
+---
+
+## 13. Acceptance criteria
+
+1. First run with no baseline creates a **provisional** baseline, does NOT auto-trust it, and sends a non-suppressible "review before trusting" notice listing web-reachable script files. `auto_bless_on_first_run` defaults false.
+2. A webshell dropped as `footer.php`/`header.php` under a (scanned) public cache dir surfaces as a **critical** card with the path shown explicitly (never in "+N more"), even right after a bless.
+3. After a bless, an unchanged subsequent run produces a delta of 0 and (with `suppress_when_no_changes`) sends nothing, but still records the run; a standing known-good drift triggers the daily drift reminder, not hourly pages.
+4. A run over 92k files hashes only size/mtime-changed files (incremental), holds bounded memory (streaming diff), and completes within `max_runtime` or records `timed_out`.
+5. `tamper_suspected` (HMAC mismatch on an existing artifact) does NOT auto-rebless and raises a high/critical signal that reaches the audit log + Laravel log + dashboard even with all notification channels disabled.
+6. A scope/exclude config change labels affected files `scope_changed`, not new/deleted, and shows a "baseline built with a different config" banner.
+7. `files_total` is stable run-to-run (a transiently unreadable file does not flip to "deleted"); the counter breakdown is reported.
+8. The Discord card never exceeds Discord limits (validated pre-POST, deterministic truncation); the Slack card renders via Block Kit; the mail card uses the executive theme. Severity color is consistent across channels and never null.
+9. `WatchCommand --once` produces identical created/updated/deleted output before and after the `Manifest` extraction (regression test).
+10. The dashboard "Run now" dispatches async and polls; the integrity queue is isolated from `default`.
+11. Prerequisite regression tests pass: `Notifiable` resolves real `to`/webhook addresses; `DiscordMessage::toArray()` has correct footer icon, string timestamp, and non-null color; `toSlack()` constructs without a class-not-found fatal; `via()` returns channel names, not event names.
+
+## 14. Test plan
+
+- **Unit**: `Manifest` diff (new/modified/deleted/scope_changed/unreadable/symlink), incremental size+mtime skip, always-hash-script-extensions, canonical key, iteration caps; `Baseline` read/write/sign/verify, atomic write, tamper-vs-corruption, dev-secret hard-fail, root hash + scope fingerprint; `SeverityColor`; severity rules (critical webshell, vendor, .env, low).
+- **Feature**: `shield:integrity` first-run provisional bless; change detection; `Notification::fake()` dispatch on `IntegrityScanCompletedEvent`; per-channel render (mail/slack/discord) with truncation + limit validation; `shield:integrity-bless` promotes last run + audits; `tamper_suspected` no-rebless + always-on escalation; suppress-when-no-changes vs drift reminder; heartbeat alert; prune retention; queue isolation; `WatchCommand --once` regression.
+- **Edge**: file vanished mid-scan, became unreadable, mass-deletion suppression on partial read, huge-diff truncation ordering + "+N more" boundary (15/16/0), timezone conversion, all-channels-disabled escalation path.
+
+## 15. Phasing
+
+- **Phase 1 (this spec)**: local-disk (docroot-aware) integrity scan + summary notification, hybrid baseline, incremental + streaming, secure-by-default, dashboard, free tier, prerequisite fixes.
+- **Phase 2 (future spec)**: first-class remote disks (sftp/s3) with ETag/LastModified pre-filter + partial-read failure budget + cleartext-FTP warning; `composer.lock` dist-hash / framework cross-check for a real known-good on first run; deploy-coordination (`bless --auto` / maintenance window) to kill `vendor/` deploy false-positives; premium real-time integrity via the watcher.
+- **Phase 3 (future spec)**: off-box authority via Central, baseline root-hash attestation, critical-alert decisioning off-box, two-person/Central-approved bless, full dead-man's-switch.
+
+## 16. Rollout notes
+
+- Ships disabled (`LS_INTEGRITY_ENABLED=false`). Enabling triggers a provisional first-run baseline + the review notice; operators must `shield:integrity-bless --confirm` after reviewing.
+- Requires a cache store with atomic locks (redis/memcached/database) when scheduled; documented, with a loud failure on the `array` store.
+- Document the honest HMAC limitation (same-host key) and that real attestation arrives in Phase 3; recommend a key file outside the web root now.
+- Document that remote-disk FIM (Phase 2) detects drift, not active tampering, and cannot defend against an attacker controlling the remote endpoint.

--- a/docs/threat-feeds.md
+++ b/docs/threat-feeds.md
@@ -8,8 +8,8 @@ Pull-based providers that import IP blocklists + WAF rules + GeoIP databases fro
 |---|---|---|---|
 | `spamhaus` | Spamhaus DROP + EDROP lists (free, public) | `ls_acl` as CIDR ranges, blacklist action | none |
 | `abuseipdb` | AbuseIPDB blacklist API (free tier 1k requests/day) | `ls_acl` as IPs, block action, 24h expiry | `LS_ABUSEIPDB_KEY` |
-| `maxmind_geolite2` | MaxMind GeoLite2 Country + ASN DBs | `storage/shield/geo/*.mmdb` — activates country/ASN ACL matchers | `LS_MAXMIND_LICENSE_KEY` + `composer require geoip2/geoip2` |
-| `maxmind_geoip2_premium` | MaxMind **paid** GeoIP2 Country/City/ISP DBs (**Premium**) | `storage/shield/geo/premium/*.mmdb` — preferred over GeoLite2, adds city/region precision | valid premium license + paid MaxMind account |
+| `maxmind_geolite2` | MaxMind GeoLite2 Country + ASN DBs | `storage/shield/geo/*.mmdb`, activates country/ASN ACL matchers | `LS_MAXMIND_LICENSE_KEY` + `composer require geoip2/geoip2` |
+| `maxmind_geoip2_premium` | MaxMind **paid** GeoIP2 Country/City/ISP DBs (**Premium**) | `storage/shield/geo/premium/*.mmdb`, preferred over GeoLite2, adds city/region precision | valid premium license + paid MaxMind account |
 | `owasp_crs` | OWASP ModSecurity CRS rule subset (via our curated JSON mirror) | `ls_waf_rules` with source=owasp_crs | none |
 | `shield_realtime` | Laravel Shield Central realtime delta feed (**Premium**) | `ls_waf_rules` + `ls_acl` with source=shield_realtime | valid premium license |
 | `emerging_threats` | Proofpoint Emerging Threats IP reputation (**Premium**) | `ls_acl` as IPs, block action, source=emerging_threats | premium license + ET token |
@@ -27,7 +27,7 @@ LS_MAXMIND_ENABLED=true
 LS_MAXMIND_LICENSE_KEY=your-maxmind-license-key
 ```
 
-Spamhaus + OWASP CRS are on by default — no API key required.
+Spamhaus + OWASP CRS are on by default, no API key required.
 
 ## Premium realtime feed (`shield_realtime`)
 
@@ -112,8 +112,8 @@ The command audit-logs each sync run with `threat_feed.sync_started` / `threat_f
 ### Spamhaus DROP / EDROP
 
 Pulls two text lists from Spamhaus:
-- `https://www.spamhaus.org/drop/drop.txt` — confirmed-bad CIDR ranges
-- `https://www.spamhaus.org/drop/edrop.txt` — confirmed-bad CIDR ranges, extended
+- `https://www.spamhaus.org/drop/drop.txt`, confirmed-bad CIDR ranges
+- `https://www.spamhaus.org/drop/edrop.txt`, confirmed-bad CIDR ranges, extended
 
 Each CIDR becomes a row in `ls_acl` with:
 - `kind = cidr`
@@ -122,7 +122,7 @@ Each CIDR becomes a row in `ls_acl` with:
 - `reason = "Spamhaus drop"` (or `edrop`)
 - `meta.list` = `drop` or `edrop`
 
-Permanent — no expiry. Re-running doesn't duplicate rows (upsert on `(kind, value)`).
+Permanent, no expiry. Re-running doesn't duplicate rows (upsert on `(kind, value)`).
 
 ### AbuseIPDB
 
@@ -133,7 +133,7 @@ Each IP becomes a row in `ls_acl` with:
 - `action = block`
 - `source = abuseipdb`
 - `reason = "AbuseIPDB confidence 95"` (varies)
-- `expires_at = now()+1d` (rolling — refreshed each sync)
+- `expires_at = now()+1d` (rolling, refreshed each sync)
 - `meta.confidence`, `meta.last_reported_at`
 
 Rate limit: free tier is 5 requests/day for blacklist endpoint. Daily cron stays well under.
@@ -160,7 +160,7 @@ The matchers cache resolved country/ASN per IP for 24h in `shield.geo.*` cache k
 
 Pulls a curated subset of OWASP ModSecurity CRS rules (currently ~200 patterns; mirrored at `raw.githubusercontent.com/OzanKurt/laravel-shield-signatures/main/owasp-crs/rules.json`).
 
-Each rule lands in `ls_waf_rules` with `source = owasp_crs`. Versioned via `version` column — bumps when the upstream pattern changes.
+Each rule lands in `ls_waf_rules` with `source = owasp_crs`. Versioned via `version` column, bumps when the upstream pattern changes.
 
 When the mirror is unreachable, an embedded fallback of ~5 critical CRS rules ships in `OwaspCrsProvider`.
 
@@ -187,7 +187,7 @@ See [architecture.md#adding-a-custom-threat-feed-provider](architecture.md#addin
 - Last run timestamp
 - Last run status (`sync_completed` / `sync_failed`)
 
-The page reads the most-recent audit log entry per provider — no separate state table.
+The page reads the most-recent audit log entry per provider, no separate state table.
 
 ## Troubleshooting
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -8,7 +8,7 @@ Common issues with concrete fixes. If your symptom isn't here, open an issue: <h
 You added an ACL block (or scoring auto-blocked you) and now every request returns 403.
 
 ### Fix
-You have three independent bypass mechanisms — see [bypass.md](bypass.md). Quickest:
+You have three independent bypass mechanisms, see [bypass.md](bypass.md). Quickest:
 
 ```bash
 # From CLI on the server:
@@ -28,9 +28,9 @@ Attacks are logged in `/shield/logs` but no `ls_acl` block row appears.
 
 ### Causes + fixes
 
-1. **`auto_block` not configured for that middleware.** Check `config/shield.php` under `shield.middleware.<name>.auto_block` — needs `attempts`, `frequency`, `period` keys.
+1. **`auto_block` not configured for that middleware.** Check `config/shield.php` under `shield.middleware.<name>.auto_block`, needs `attempts`, `frequency`, `period` keys.
 2. **Window not exceeded yet.** Auto-block requires `attempts` attacks within `frequency` seconds. Lower the threshold if needed.
-3. **Logs aren't writing to the new `ls_logs` table.** Check `SELECT COUNT(*) FROM ls_logs WHERE created_at > NOW() - INTERVAL 1 HOUR` — if 0, you're hitting the legacy `BlockIpListener` that targets the dropped `security_ips` table. Workaround until the listener is ported: add manual ACL rows or use the suspicion scorer instead.
+3. **Logs aren't writing to the new `ls_logs` table.** Check `SELECT COUNT(*) FROM ls_logs WHERE created_at > NOW() - INTERVAL 1 HOUR`, if 0, you're hitting the legacy `BlockIpListener` that targets the dropped `security_ips` table. Workaround until the listener is ported: add manual ACL rows or use the suspicion scorer instead.
 
 ## Dashboard returns 403
 
@@ -109,7 +109,7 @@ These are scheduled for porting in a follow-up patch. Workaround: comment out th
 GitHub API rate limit (60 req/h for unauthenticated). Sync falls back to embedded signatures automatically.
 
 ### Fix
-Optionally authenticate the GitHub API call by setting `GITHUB_TOKEN` in `.env` — `LS_SIGNATURE_URL` requests will include the token.
+Optionally authenticate the GitHub API call by setting `GITHUB_TOKEN` in `.env`, `LS_SIGNATURE_URL` requests will include the token.
 
 ## Audit log chain breaks ("chain mismatch at id N")
 
@@ -118,7 +118,7 @@ Optionally authenticate the GitHub API call by setting `GITHUB_TOKEN` in `.env` 
 
 ### Causes + fixes
 
-1. **Someone manually edited a row.** Quote the audit log row, restore the original data, and re-verify. The chain is tamper-evident — a verification failure is the alarm working.
+1. **Someone manually edited a row.** Quote the audit log row, restore the original data, and re-verify. The chain is tamper-evident, a verification failure is the alarm working.
 2. **Race condition on parallel writes.** Concurrent `AuditLogger::log()` calls can race on reading the previous row. Switch storage driver to `queue` so writes serialize:
 
    ```env
@@ -136,7 +136,7 @@ You're hitting the app but `/shield/live-traffic` is empty.
 
 1. **Sampling discarded the requests.** Default sample rate is 0.1 (1 in 10). Hit the page 20+ times to see entries, or set `LS_LIVE_TRAFFIC_SAMPLE_RATE=1.0` temporarily.
 2. **`firewall.live_traffic` isn't in your middleware stack.** It's auto-included in `firewall.all` but if you wired middlewares à la carte, add `firewall.live_traffic` to your route group.
-3. **Skip pattern is too broad.** Check `shield.live_traffic.skip_paths` — default skips `shield/*`, `_debugbar/*`, asset paths, health checks.
+3. **Skip pattern is too broad.** Check `shield.live_traffic.skip_paths`, default skips `shield/*`, `_debugbar/*`, asset paths, health checks.
 
 ## Premium features not activating
 
@@ -147,7 +147,7 @@ You set `LS_PREMIUM_LICENSE_KEY` but `Shield::isPremium()` returns false.
 
 1. **Cache hasn't expired yet.** License check is cached 24h. Run `php artisan cache:forget shield.premium.license` to force re-check.
 2. **License-check API unreachable.** During the 7-day grace period after unreachability, the cached "valid" status persists. After the grace expires, features deactivate. Check `php artisan shield:license` for grace state.
-3. **Domain limit exceeded.** Each license activates on a fixed number of domains. The dashboard's "License" page shows `domains_used / domain_limit` — contact support to extend if needed.
+3. **Domain limit exceeded.** Each license activates on a fixed number of domains. The dashboard's "License" page shows `domains_used / domain_limit`, contact support to extend if needed.
 
 ## CSP nonce isn't working
 

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -47,6 +47,12 @@ return [
         ],
     ],
 
+    'integrity_changed' => [
+        'title' => 'File integrity scan — :disk (:time)',
+        'summary' => ':new new · :modified modified · :deleted deleted · :total files total',
+        'drift' => ':count files still differ from the approved baseline.',
+    ],
+
     'security_report' => [
         'mail' => [
             'subject' => 'Security Report for :domain',

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -32,10 +32,33 @@ return [
         ],
     ],
 
+    'failed_login' => [
+        'mail' => [
+            'subject' => 'Failed login attempt on :domain',
+            'message' => 'A failed login attempt was detected on :domain.',
+        ],
+
+        'slack' => [
+            'message' => 'Failed login attempt on :domain',
+        ],
+
+        'discord' => [
+            'message' => 'Failed login attempt on :domain',
+        ],
+    ],
+
     'security_report' => [
         'mail' => [
             'subject' => 'Security Report for :domain',
             'message' => 'This email was sent by your :domain site and contains a security report for the period :start - :end.',
+        ],
+
+        'slack' => [
+            'message' => 'Security report for :domain (:start - :end).',
+        ],
+
+        'discord' => [
+            'message' => 'Security report for :domain (:start - :end).',
         ],
 
         // Section titles

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -48,7 +48,7 @@ return [
     ],
 
     'integrity_changed' => [
-        'title' => 'File integrity scan — :disk (:time)',
+        'title' => 'File integrity scan: :disk (:time)',
         'summary' => ':new new · :modified modified · :deleted deleted · :total files total',
         'drift' => ':count files still differ from the approved baseline.',
     ],

--- a/resources/views/dashboard/audit-log/index.blade.php
+++ b/resources/views/dashboard/audit-log/index.blade.php
@@ -15,7 +15,7 @@
                                 <div class="col-md-3">
                                     <label class="form-label small">@lang('shield::dashboard.columns.kind')</label>
                                     <select id="filterKind" name="filter_kind_id" class="form-select form-select-sm">
-                                        <option value="">— All —</option>
+                                        <option value="">- All -</option>
                                         @foreach($kinds as $kind)
                                             <option value="{{ $kind->id }}">{{ $kind->label }}</option>
                                         @endforeach
@@ -24,7 +24,7 @@
                                 <div class="col-md-2">
                                     <label class="form-label small">@lang('shield::dashboard.columns.severity')</label>
                                     <select id="filterSeverity" name="filter_severity_id" class="form-select form-select-sm">
-                                        <option value="">— All —</option>
+                                        <option value="">- All -</option>
                                         @foreach($severities as $sev)
                                             <option value="{{ $sev->id }}">{{ $sev->label }}</option>
                                         @endforeach
@@ -33,7 +33,7 @@
                                 <div class="col-md-2">
                                     <label class="form-label small">@lang('shield::dashboard.columns.actor_type')</label>
                                     <select id="filterActorType" name="filter_actor_type" class="form-select form-select-sm">
-                                        <option value="">— All —</option>
+                                        <option value="">- All -</option>
                                         <option value="user">user</option>
                                         <option value="system">system</option>
                                         <option value="cli">cli</option>

--- a/resources/views/dashboard/integrity/changes.blade.php
+++ b/resources/views/dashboard/integrity/changes.blade.php
@@ -1,0 +1,47 @@
+@extends('shield::layouts.bootstrap.app')
+
+@section('content')
+    <div class="mt-5">
+        <h2>Integrity changes</h2>
+
+        <div class="card shadow mt-3">
+            <div class="card-body">
+                <table id="integrityChangesTable" class="table table-sm table-hover">
+                    <thead>
+                        <tr>
+                            <th>Run</th>
+                            <th>Path</th>
+                            <th>Change</th>
+                            <th>Compared to</th>
+                            <th>Severity</th>
+                        </tr>
+                    </thead>
+                </table>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@push('scripts')
+<script>
+$(function () {
+    const params = new URLSearchParams(window.location.search);
+    $('#integrityChangesTable').DataTable({
+        processing: true,
+        serverSide: true,
+        responsive: true,
+        ajax: {
+            url: '{{ app('shield')->route('integrity.changes') }}',
+            data: { mode: 'dataTable', run_id: params.get('run_id') || '' },
+        },
+        columns: [
+            { data: 'run' },
+            { data: 'path' },
+            { data: 'change_type' },
+            { data: 'compared_to' },
+            { data: 'severity' },
+        ],
+    });
+});
+</script>
+@endpush

--- a/resources/views/dashboard/integrity/index.blade.php
+++ b/resources/views/dashboard/integrity/index.blade.php
@@ -9,7 +9,7 @@
                 <div class="card shadow">
                     <div class="card-body">
                         <div class="text-muted small">Latest run</div>
-                        <div class="fs-4">{{ $stats['latest_run'] ? '#'.$stats['latest_run']->id : '—' }}</div>
+                        <div class="fs-4">{{ $stats['latest_run'] ? '#'.$stats['latest_run']->id : '-' }}</div>
                         <div class="small text-muted">{{ $stats['latest_run_status'] ?? '' }}</div>
                     </div>
                 </div>
@@ -26,7 +26,7 @@
                 <div class="card shadow">
                     <div class="card-body">
                         <div class="text-muted small">Baseline</div>
-                        <div class="fs-4">{{ $stats['baseline'] ? ($stats['baseline']->signed ? 'Approved' : 'Provisional') : '—' }}</div>
+                        <div class="fs-4">{{ $stats['baseline'] ? ($stats['baseline']->signed ? 'Approved' : 'Provisional') : '-' }}</div>
                         <div class="small text-muted">{{ $stats['baseline'] ? $stats['baseline']->files_total.' files' : 'not established' }}</div>
                     </div>
                 </div>

--- a/resources/views/dashboard/integrity/index.blade.php
+++ b/resources/views/dashboard/integrity/index.blade.php
@@ -1,0 +1,102 @@
+@extends('shield::layouts.bootstrap.app')
+
+@section('content')
+    <div class="mt-5">
+        <h2>File integrity</h2>
+
+        <div class="row mt-4 g-3">
+            <div class="col-md-3">
+                <div class="card shadow">
+                    <div class="card-body">
+                        <div class="text-muted small">Latest run</div>
+                        <div class="fs-4">{{ $stats['latest_run'] ? '#'.$stats['latest_run']->id : '—' }}</div>
+                        <div class="small text-muted">{{ $stats['latest_run_status'] ?? '' }}</div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-3">
+                <div class="card shadow">
+                    <div class="card-body">
+                        <div class="text-muted small">Total runs</div>
+                        <div class="fs-4">{{ $stats['total_runs'] }}</div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-3">
+                <div class="card shadow">
+                    <div class="card-body">
+                        <div class="text-muted small">Baseline</div>
+                        <div class="fs-4">{{ $stats['baseline'] ? ($stats['baseline']->signed ? 'Approved' : 'Provisional') : '—' }}</div>
+                        <div class="small text-muted">{{ $stats['baseline'] ? $stats['baseline']->files_total.' files' : 'not established' }}</div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-3">
+                <div class="card shadow">
+                    <div class="card-body">
+                        <div class="text-muted small">Differs from baseline</div>
+                        <div class="fs-4">{{ $stats['drift'] }}</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        @if ($stats['baseline'] && ! $stats['baseline']->signed)
+            <div class="alert alert-warning mt-4">
+                A provisional baseline was established from the current disk state and is <strong>not yet trusted</strong>.
+                Review the files, then click <em>Approve baseline</em>.
+            </div>
+        @endif
+
+        <div class="row mt-4">
+            <div class="col-12">
+                <div class="card shadow">
+                    <div class="card-body">
+                        <h5>Run / approve</h5>
+                        <form id="integrityForm" class="row g-2">
+                            <div class="col-md-6">
+                                <label class="form-label small">Disk</label>
+                                <input type="text" name="disk" class="form-control form-control-sm" value="app">
+                            </div>
+                            <div class="col-md-6 d-flex align-items-end gap-2">
+                                <button type="button" id="runBtn" class="btn btn-primary btn-sm">Run scan</button>
+                                <button type="button" id="blessBtn" class="btn btn-outline-secondary btn-sm">Approve baseline</button>
+                            </div>
+                        </form>
+                        <pre id="integrityResult" class="mt-3 small" style="display:none;"></pre>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="row mt-4">
+            <div class="col-12">
+                <ul class="nav nav-pills">
+                    <li class="nav-item"><a class="nav-link" href="{{ app('shield')->route('integrity.runs') }}">Runs</a></li>
+                    <li class="nav-item"><a class="nav-link" href="{{ app('shield')->route('integrity.changes') }}">Changes</a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@push('scripts')
+<script>
+$(function () {
+    function post(url) {
+        const disk = $('[name=disk]').val();
+        $('#integrityResult').show().text('Working...');
+        $.post(url, { disk })
+            .done(function (res) {
+                const msgs = (res.actions || []).filter(a => a.type === 'toastr').map(a => a.data.message);
+                $('#integrityResult').text(msgs.join('\n') || JSON.stringify(res, null, 2));
+            })
+            .fail(function (xhr) {
+                $('#integrityResult').text('Error: ' + (xhr.responseText || xhr.statusText));
+            });
+    }
+    $('#runBtn').on('click', () => post('{{ app('shield')->route('integrity.scan') }}'));
+    $('#blessBtn').on('click', () => post('{{ app('shield')->route('integrity.bless') }}'));
+});
+</script>
+@endpush

--- a/resources/views/dashboard/integrity/runs.blade.php
+++ b/resources/views/dashboard/integrity/runs.blade.php
@@ -1,0 +1,56 @@
+@extends('shield::layouts.bootstrap.app')
+
+@section('content')
+    <div class="mt-5">
+        <h2>Integrity runs</h2>
+
+        <div class="card shadow mt-3">
+            <div class="card-body">
+                <table id="integrityRunsTable" class="table table-sm table-hover">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>UUID</th>
+                            <th>Disk</th>
+                            <th>Status</th>
+                            <th>Severity</th>
+                            <th>New</th>
+                            <th>Modified</th>
+                            <th>Deleted</th>
+                            <th>Vs baseline</th>
+                            <th>Files</th>
+                            <th>Started</th>
+                        </tr>
+                    </thead>
+                </table>
+            </div>
+        </div>
+    </div>
+@endsection
+
+@push('scripts')
+<script>
+$(function () {
+    $('#integrityRunsTable').DataTable({
+        processing: true,
+        serverSide: true,
+        responsive: true,
+        order: [[0, 'desc']],
+        ajax: { url: '{{ app('shield')->route('integrity.runs') }}', data: { mode: 'dataTable' } },
+        columns: [
+            { data: 'id' },
+            { data: 'uuid' },
+            { data: 'disk' },
+            { data: 'status' },
+            { data: 'severity' },
+            { data: 'new' },
+            { data: 'modified' },
+            { data: 'deleted' },
+            { data: 'vs_known_good' },
+            { data: 'files_total' },
+            { data: 'started_at' },
+        ],
+    });
+});
+</script>
+@endpush

--- a/resources/views/dashboard/license/index.blade.php
+++ b/resources/views/dashboard/license/index.blade.php
@@ -69,7 +69,7 @@
                 <div class="alert alert-warning mt-3 mb-0">
                     <strong>Central license API is unreachable.</strong>
                     Your premium features stay active until
-                    <strong>{{ $state['grace_until'] ?? '—' }}</strong>.
+                    <strong>{{ $state['grace_until'] ?? '-' }}</strong>.
                     Resolve before that to avoid feature deactivation.
                 </div>
             @elseif($stateKey === 'invalid')
@@ -94,15 +94,15 @@
                                 </tr>
                                 <tr>
                                     <th class="ps-3">Plan</th>
-                                    <td>{{ $state['plan'] ?? '—' }}</td>
+                                    <td>{{ $state['plan'] ?? '-' }}</td>
                                 </tr>
                                 <tr>
                                     <th class="ps-3">Expires</th>
-                                    <td>{{ $state['expires_at'] ?? '—' }}</td>
+                                    <td>{{ $state['expires_at'] ?? '-' }}</td>
                                 </tr>
                                 <tr>
                                     <th class="ps-3">Last checked</th>
-                                    <td>{{ $state['last_checked_at'] ?? '—' }}</td>
+                                    <td>{{ $state['last_checked_at'] ?? '-' }}</td>
                                 </tr>
                                 @if(! empty($state['last_valid_at']))
                                     <tr>
@@ -132,7 +132,7 @@
                                         @if(isset($state['domain_limit']))
                                             {{ $state['domains_used'] ?? '?' }} / {{ $state['domain_limit'] }}
                                         @else
-                                            —
+                                            -
                                         @endif
                                     </td>
                                 </tr>

--- a/resources/views/dashboard/scanner/index.blade.php
+++ b/resources/views/dashboard/scanner/index.blade.php
@@ -9,7 +9,7 @@
                 <div class="card shadow">
                     <div class="card-body">
                         <div class="text-muted small">Latest run</div>
-                        <div class="fs-4">{{ $stats['latest_run'] ? '#'.$stats['latest_run']->id : '—' }}</div>
+                        <div class="fs-4">{{ $stats['latest_run'] ? '#'.$stats['latest_run']->id : '-' }}</div>
                         <div class="small text-muted">{{ $stats['latest_run_status'] ?? '' }}</div>
                     </div>
                 </div>

--- a/resources/views/dashboard/webhook-deliveries/index.blade.php
+++ b/resources/views/dashboard/webhook-deliveries/index.blade.php
@@ -6,7 +6,7 @@
             <div>
                 <h2 class="mb-0">Webhook deliveries</h2>
                 <p class="text-muted small mb-0">
-                    Outbound calls to Central — webhook ingest, heartbeat, test pings.
+                    Outbound calls to Central, webhook ingest, heartbeat, test pings.
                 </p>
             </div>
             <form method="GET" class="d-flex align-items-center gap-2 flex-wrap">
@@ -89,12 +89,12 @@
                                 <td class="ps-3 text-muted small">{{ $d->dispatched_at?->format('Y-m-d H:i:s') }}</td>
                                 <td><code class="small">{{ $d->operation }}</code></td>
                                 <td><span class="badge {{ $color }}">{{ $d->status }}</span></td>
-                                <td>{{ $d->http_status ?: '—' }}</td>
+                                <td>{{ $d->http_status ?: '-' }}</td>
                                 <td>{{ $d->attempt_number }}/{{ $d->max_attempts }}</td>
                                 <td>{{ $d->payload_bytes }}</td>
-                                <td>{{ $d->duration_ms !== null ? $d->duration_ms . 'ms' : '—' }}</td>
+                                <td>{{ $d->duration_ms !== null ? $d->duration_ms . 'ms' : '-' }}</td>
                                 <td class="text-muted small" style="max-width: 320px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="{{ $d->reason }}">
-                                    {{ $d->reason ?? ($d->response_excerpt ? substr($d->response_excerpt, 0, 80) : '—') }}
+                                    {{ $d->reason ?? ($d->response_excerpt ? substr($d->response_excerpt, 0, 80) : '-') }}
                                 </td>
                                 <td class="pe-3">
                                     @if(in_array($d->status, ['failure','exhausted']) && $d->operation === 'webhook_ingest')
@@ -107,7 +107,7 @@
                             </tr>
                         @empty
                             <tr><td colspan="9" class="text-center text-muted py-4">
-                                No deliveries yet — make sure premium is active + a queue worker is running.
+                                No deliveries yet, make sure premium is active + a queue worker is running.
                             </td></tr>
                         @endforelse
                     </tbody>

--- a/resources/views/layouts/bootstrap/_navbar.blade.php
+++ b/resources/views/layouts/bootstrap/_navbar.blade.php
@@ -62,6 +62,13 @@
                     </a>
                 </li>
                 <li class="nav-item">
+                    <a class="nav-link {{ app('shield')->routeIsActive('integrity.index') ? 'active' : '' }}"
+                       href="{{ app('shield')->route('integrity.index') }}"
+                    >
+                        Integrity
+                    </a>
+                </li>
+                <li class="nav-item">
                     <a class="nav-link {{ app('shield')->routeIsActive('cache.index') ? 'active' : '' }}"
                        href="{{ app('shield')->route('cache.index') }}"
                     >

--- a/resources/views/layouts/bootstrap/_navbar.blade.php
+++ b/resources/views/layouts/bootstrap/_navbar.blade.php
@@ -88,7 +88,7 @@
                     >
                         License
                         {{--
-                            CACHE-ONLY read — must never trigger an HTTP
+                            CACHE-ONLY read, must never trigger an HTTP
                             call to Central. licenseState() would refresh
                             on cache miss + stall every dashboard page up
                             to http_timeout seconds. Badge stays neutral

--- a/src/Concerns/HasAuditLog.php
+++ b/src/Concerns/HasAuditLog.php
@@ -16,9 +16,9 @@ use OzanKurt\Shield\Services\Lookups\LookupResolver;
  *   }
  *
  * Overridable hooks (define on the model to customise behaviour):
- *   - auditLogChanges(): array   — what goes in the `changes` column (default: getDirty())
- *   - auditLogMeta(): array      — additional metadata stored in `meta`
- *   - auditLogShouldLog(string $event): bool — return false to suppress specific events
+ *   - auditLogChanges(): array  , what goes in the `changes` column (default: getDirty())
+ *   - auditLogMeta(): array     , additional metadata stored in `meta`
+ *   - auditLogShouldLog(string $event): bool, return false to suppress specific events
  */
 trait HasAuditLog
 {

--- a/src/Console/Commands/BypassListCommand.php
+++ b/src/Console/Commands/BypassListCommand.php
@@ -32,8 +32,8 @@ class BypassListCommand extends Command
             $entries->map(fn ($e) => [
                 $e->id,
                 $e->value,
-                $e->reason ?? '—',
-                $e->created_at?->toDateTimeString() ?? '—',
+                $e->reason ?? '-',
+                $e->created_at?->toDateTimeString() ?? '-',
             ])->toArray(),
         );
 

--- a/src/Console/Commands/CentralTestCommand.php
+++ b/src/Console/Commands/CentralTestCommand.php
@@ -12,9 +12,9 @@ use OzanKurt\Shield\Services\Premium\WebhookSigner;
  *
  * Runs three checks in sequence + reports a clear pass/fail summary:
  *
- *   1. License check     — does Central recognise our key + return valid?
- *   2. Signed heartbeat  — can we POST a signed request + get 2xx?
- *   3. Test ping         — does the signed echo endpoint roundtrip?
+ *   1. License check    , does Central recognise our key + return valid?
+ *   2. Signed heartbeat , can we POST a signed request + get 2xx?
+ *   3. Test ping        , does the signed echo endpoint roundtrip?
  *
  * Anything other than 3/3 PASS means the install is misconfigured.
  * The dashboard "Test connectivity" button calls the same code path,
@@ -37,17 +37,17 @@ class CentralTestCommand extends Command
         // 1. License check
         $this->line(' [1/3] License check…');
         if (! $checker->hasKey()) {
-            $this->line('       <fg=red>SKIP</> — no LS_PREMIUM_LICENSE_KEY configured.');
+            $this->line('       <fg=red>SKIP</>, no LS_PREMIUM_LICENSE_KEY configured.');
         } else {
             $state = $checker->refresh();
             if (in_array($state['state'] ?? null, ['valid', 'grace'], true)) {
                 $plan = $state['plan'] ?? 'unknown';
                 $exp = $state['expires_at'] ?? 'no expiry';
-                $this->line("       <fg=green>PASS</> — plan={$plan}, expires={$exp}");
+                $this->line("       <fg=green>PASS</>, plan={$plan}, expires={$exp}");
                 $passed++;
             } else {
                 $reason = $state['reason'] ?? 'unknown';
-                $this->line("       <fg=red>FAIL</> — state={$state['state']}, reason={$reason}");
+                $this->line("       <fg=red>FAIL</>, state={$state['state']}, reason={$reason}");
             }
         }
 
@@ -55,14 +55,14 @@ class CentralTestCommand extends Command
         $this->newLine();
         $this->line(' [2/3] Webhook signing capability…');
         if (! $signer->canSign()) {
-            $this->line('       <fg=red>FAIL</> — no signing secret resolvable (set LS_PREMIUM_LICENSE_KEY or LS_PREMIUM_WEBHOOK_SECRET).');
+            $this->line('       <fg=red>FAIL</>, no signing secret resolvable (set LS_PREMIUM_LICENSE_KEY or LS_PREMIUM_WEBHOOK_SECRET).');
         } else {
             $sampleBody = '{"test":1}';
             $headers = $signer->sign($sampleBody);
             if (! isset($headers['X-Shield-Signature'], $headers['X-Shield-Timestamp'], $headers['X-Shield-Nonce'])) {
-                $this->line('       <fg=red>FAIL</> — signer returned incomplete header set.');
+                $this->line('       <fg=red>FAIL</>, signer returned incomplete header set.');
             } else {
-                $this->line('       <fg=green>PASS</> — signature header present + 3-tuple complete.');
+                $this->line('       <fg=green>PASS</>, signature header present + 3-tuple complete.');
                 $passed++;
             }
         }
@@ -76,13 +76,13 @@ class CentralTestCommand extends Command
             'php_version' => PHP_VERSION,
         ]);
         if ($result->ok()) {
-            $this->line("       <fg=green>PASS</> — HTTP {$result->httpStatus} from {$result->url}");
+            $this->line("       <fg=green>PASS</>, HTTP {$result->httpStatus} from {$result->url}");
             $passed++;
         } elseif ($result->outcome === 'skipped') {
-            $this->line("       <fg=yellow>SKIP</> — {$result->error}");
+            $this->line("       <fg=yellow>SKIP</>, {$result->error}");
         } else {
             $status = $result->httpStatus ?: 'no response';
-            $this->line("       <fg=red>FAIL</> — status={$status}, reason={$result->error}");
+            $this->line("       <fg=red>FAIL</>, status={$status}, reason={$result->error}");
             if ($result->responseExcerpt) {
                 $this->line('       Response: ' . substr($result->responseExcerpt, 0, 200));
             }

--- a/src/Console/Commands/FeedSyncCommand.php
+++ b/src/Console/Commands/FeedSyncCommand.php
@@ -26,7 +26,7 @@ class FeedSyncCommand extends Command
             $r->success() ? 'OK' : 'FAIL',
             $r->imported,
             $r->updated,
-            $r->error ?? '—',
+            $r->error ?? '-',
         ], $results);
 
         $this->table(['Provider', 'Status', 'Imported', 'Updated', 'Error'], $rows);

--- a/src/Console/Commands/HeartbeatCommand.php
+++ b/src/Console/Commands/HeartbeatCommand.php
@@ -15,12 +15,12 @@ class HeartbeatCommand extends Command
     public function handle(LicenseChecker $checker, CentralClient $client): int
     {
         if (! $checker->hasKey()) {
-            $this->warn('No premium license key configured — heartbeat skipped.');
+            $this->warn('No premium license key configured, heartbeat skipped.');
             return self::SUCCESS;
         }
 
         if (! $checker->isPremium() && ! $this->option('force')) {
-            $this->warn('Premium license inactive — heartbeat skipped (use --force to override).');
+            $this->warn('Premium license inactive, heartbeat skipped (use --force to override).');
             return self::SUCCESS;
         }
 
@@ -38,7 +38,7 @@ class HeartbeatCommand extends Command
             return self::SUCCESS;
         }
 
-        $this->warn("Heartbeat failed (status={$result->httpStatus}, reason={$result->error}) — see logs + /shield/webhook-deliveries.");
+        $this->warn("Heartbeat failed (status={$result->httpStatus}, reason={$result->error}), see logs + /shield/webhook-deliveries.");
         return self::FAILURE;
     }
 
@@ -110,7 +110,7 @@ class HeartbeatCommand extends Command
         // src/Console/Commands/HeartbeatCommand.php → package root is
         // THREE directories up (../../../composer.json). This file is
         // one level shallower than LicenseChecker, so the path is
-        // genuinely different — keep them in sync if directory depth
+        // genuinely different, keep them in sync if directory depth
         // ever changes.
         $composerJson = __DIR__ . '/../../../composer.json';
 

--- a/src/Console/Commands/IntegrityBlessCommand.php
+++ b/src/Console/Commands/IntegrityBlessCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace OzanKurt\Shield\Console\Commands;
+
+use Illuminate\Console\Command;
+use InvalidArgumentException;
+use OzanKurt\Shield\Services\Integrity\IntegrityScanner;
+
+class IntegrityBlessCommand extends Command
+{
+    protected $signature = 'shield:integrity-bless {--disk=app : Configured integrity disk to bless}';
+    protected $description = 'Promote the most recent integrity scan state to the approved known-good baseline.';
+
+    public function handle(IntegrityScanner $scanner): int
+    {
+        $disk = (string) $this->option('disk');
+
+        try {
+            $baseline = $scanner->bless($disk);
+        } catch (InvalidArgumentException $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->info("Baseline approved for disk [{$disk}]: {$baseline->files_total} files (root {$baseline->root_hash}).");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/IntegrityHeartbeatCommand.php
+++ b/src/Console/Commands/IntegrityHeartbeatCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace OzanKurt\Shield\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use OzanKurt\Shield\Models\IntegrityRun;
+use OzanKurt\Shield\Models\Lookups\IntegrityStatus;
+
+/**
+ * Dead-man's-switch: warns when integrity scans have silently stopped running.
+ * A security control that quietly stops is indistinguishable from "all clear",
+ * so the absence of a recent successful run is itself an alertable signal.
+ */
+class IntegrityHeartbeatCommand extends Command
+{
+    protected $signature = 'shield:integrity-heartbeat {--disk=app : Configured integrity disk}';
+    protected $description = 'Warn when no successful integrity scan has completed within the freshness window.';
+
+    public function handle(): int
+    {
+        $disk = (string) $this->option('disk');
+        $maxAgeHours = (int) config('shield.integrity.heartbeat.max_age_hours', 26);
+
+        $successIds = IntegrityStatus::whereIn('name', ['completed', 'baseline_established'])->pluck('id');
+
+        $last = IntegrityRun::where('disk', $disk)
+            ->whereIn('status_id', $successIds)
+            ->latest('id')
+            ->first();
+
+        if ($last === null || $last->finished_at === null || $last->finished_at->lt(now()->subHours($maxAgeHours))) {
+            $message = "Shield integrity: no successful scan for disk [{$disk}] within {$maxAgeHours}h. Scanning may be disabled or stuck.";
+            Log::warning($message);
+            $this->warn($message);
+
+            return self::FAILURE;
+        }
+
+        $this->info("OK: last successful integrity scan for [{$disk}] finished {$last->finished_at->diffForHumans()}.");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/IntegrityPruneCommand.php
+++ b/src/Console/Commands/IntegrityPruneCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace OzanKurt\Shield\Console\Commands;
+
+use Illuminate\Console\Command;
+use OzanKurt\Shield\Models\IntegrityChange;
+use OzanKurt\Shield\Models\IntegrityRun;
+
+class IntegrityPruneCommand extends Command
+{
+    protected $signature = 'shield:integrity-prune';
+    protected $description = 'Hard-delete old integrity runs and change rows per the configured retention.';
+
+    public function handle(): int
+    {
+        $runsDays = (int) config('shield.integrity.retention.runs_days', 90);
+        $changesDays = (int) config('shield.integrity.retention.changes_days', 30);
+
+        // Delete old runs together with ALL their change rows (avoids FK violations),
+        // then prune leftover old change rows belonging to surviving runs.
+        $oldRunIds = IntegrityRun::where('created_at', '<', now()->subDays($runsDays))->pluck('id');
+
+        $deletedChanges = 0;
+        if ($oldRunIds->isNotEmpty()) {
+            $deletedChanges += IntegrityChange::whereIn('integrity_run_id', $oldRunIds)->forceDelete();
+        }
+
+        $deletedRuns = IntegrityRun::whereIn('id', $oldRunIds)->forceDelete();
+        $deletedChanges += IntegrityChange::where('created_at', '<', now()->subDays($changesDays))->forceDelete();
+
+        $this->info("Pruned {$deletedRuns} runs and {$deletedChanges} change rows.");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/IntegrityScanCommand.php
+++ b/src/Console/Commands/IntegrityScanCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace OzanKurt\Shield\Console\Commands;
+
+use Illuminate\Console\Command;
+use OzanKurt\Shield\Services\Integrity\IntegrityScanner;
+
+class IntegrityScanCommand extends Command
+{
+    protected $signature = 'shield:integrity {--disk=app : Configured integrity disk to scan} {--trigger=manual : Trigger source for this run}';
+    protected $description = 'Run a file-integrity scan: diff the filesystem against the approved baseline and the previous run.';
+
+    public function handle(IntegrityScanner $scanner): int
+    {
+        $disk = (string) $this->option('disk');
+        $trigger = (string) $this->option('trigger');
+
+        $this->info("Running integrity scan on disk [{$disk}]...");
+
+        $run = $scanner->run($disk, $trigger);
+        $status = $run->status->name ?? 'unknown';
+
+        $this->table(['Field', 'Value'], [
+            ['UUID', $run->uuid],
+            ['Status', $status],
+            ['Files total', $run->files_total],
+            ['New', $run->count_new],
+            ['Modified', $run->count_modified],
+            ['Deleted', $run->count_deleted],
+            ['Vs known-good', $run->count_vs_known_good],
+        ]);
+
+        if ($status === 'baseline_established') {
+            $this->warn('Provisional baseline established from the current disk state. It is NOT yet trusted. Review the files, then run `shield:integrity-bless` to approve it.');
+        }
+
+        if ($status === 'tamper_suspected') {
+            $this->error('Baseline signature did not verify. Possible tampering. The baseline was NOT rebuilt.');
+
+            return 2;
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/IntegrityStatusCommand.php
+++ b/src/Console/Commands/IntegrityStatusCommand.php
@@ -23,8 +23,8 @@ class IntegrityStatusCommand extends Command
         } else {
             $this->table(['Field', 'Value'], [
                 ['Run', '#' . $run->id],
-                ['Status', $run->status->name ?? '—'],
-                ['Severity', $run->severity->name ?? '—'],
+                ['Status', $run->status->name ?? '-'],
+                ['Severity', $run->severity->name ?? '-'],
                 ['Files total', $run->files_total],
                 ['New / Modified / Deleted', "{$run->count_new} / {$run->count_modified} / {$run->count_deleted}"],
                 ['Differs from baseline', $run->count_vs_known_good],

--- a/src/Console/Commands/IntegrityStatusCommand.php
+++ b/src/Console/Commands/IntegrityStatusCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace OzanKurt\Shield\Console\Commands;
+
+use Illuminate\Console\Command;
+use OzanKurt\Shield\Models\IntegrityBaseline;
+use OzanKurt\Shield\Models\IntegrityRun;
+
+class IntegrityStatusCommand extends Command
+{
+    protected $signature = 'shield:integrity-status {--disk=app : Configured integrity disk}';
+    protected $description = 'Show the latest integrity run and baseline state for a disk.';
+
+    public function handle(): int
+    {
+        $disk = (string) $this->option('disk');
+
+        $run = IntegrityRun::where('disk', $disk)->latest('id')->first();
+        $baseline = IntegrityBaseline::where('disk', $disk)->latest('id')->first();
+
+        if ($run === null) {
+            $this->warn("No integrity runs recorded for disk [{$disk}]. Run `shield:integrity --disk={$disk}`.");
+        } else {
+            $this->table(['Field', 'Value'], [
+                ['Run', '#' . $run->id],
+                ['Status', $run->status->name ?? '—'],
+                ['Severity', $run->severity->name ?? '—'],
+                ['Files total', $run->files_total],
+                ['New / Modified / Deleted', "{$run->count_new} / {$run->count_modified} / {$run->count_deleted}"],
+                ['Differs from baseline', $run->count_vs_known_good],
+                ['Finished', (string) $run->finished_at],
+            ]);
+        }
+
+        if ($baseline === null) {
+            $this->line("Baseline: none established for disk [{$disk}].");
+        } else {
+            $state = $baseline->signed ? 'approved' : 'provisional (not yet trusted)';
+            $this->line("Baseline: {$state}, {$baseline->files_total} files, root {$baseline->root_hash}.");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/ReportSendCommand.php
+++ b/src/Console/Commands/ReportSendCommand.php
@@ -29,10 +29,10 @@ class ReportSendCommand extends Command
 
         // Multi-cadence reports beyond the daily digest are premium. Free
         // tier keeps daily_digest working; 3/7/14/30-day reports require
-        // a premium license. Soft enforcement — falls open if Central is
+        // a premium license. Soft enforcement, falls open if Central is
         // unreachable AND the cached state hasn't been seen as valid.
         if ($cadence !== 'daily_digest' && ! Shield::isFeatureAvailable('multi_cadence_reports')) {
-            $this->warn("Cadence {$cadence} requires a premium license — skipping. Run shield:license:status to check.");
+            $this->warn("Cadence {$cadence} requires a premium license, skipping. Run shield:license:status to check.");
             return self::SUCCESS;
         }
 
@@ -46,7 +46,7 @@ class ReportSendCommand extends Command
             // The actual channel dispatch logic lives in the existing notification stack;
             // for the immediate 1.0.0 release the email template is the canonical sink.
             $this->info("Report generated: {$cadence}");
-            $this->table(['Section', 'Count'], collect($payload['sections'])->map(fn ($v, $k) => [$k, is_countable($v) ? count($v) : '—'])->values()->all());
+            $this->table(['Section', 'Count'], collect($payload['sections'])->map(fn ($v, $k) => [$k, is_countable($v) ? count($v) : '-'])->values()->all());
         } catch (Throwable $e) {
             $this->error("Report generation failed: {$e->getMessage()}");
             return self::FAILURE;

--- a/src/Console/Commands/SignaturesSyncCommand.php
+++ b/src/Console/Commands/SignaturesSyncCommand.php
@@ -165,7 +165,7 @@ class SignaturesSyncCommand extends Command
             return [];
         }
 
-        // Direct signature array — the Central app channel response.
+        // Direct signature array, the Central app channel response.
         if ($this->looksLikeSignatureList($payload)) {
             return $payload;
         }
@@ -215,7 +215,7 @@ class SignaturesSyncCommand extends Command
             }
         }
 
-        // Strategy 2: inline JSON in the release body — look for a fenced ```json block
+        // Strategy 2: inline JSON in the release body, look for a fenced ```json block
         $body = (string) ($payload['body'] ?? '');
         if (preg_match('/```json\s*([\s\S]+?)\s*```/', $body, $match)) {
             $decoded = json_decode($match[1], true);

--- a/src/Events/IntegrityScanCompletedEvent.php
+++ b/src/Events/IntegrityScanCompletedEvent.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace OzanKurt\Shield\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use OzanKurt\Shield\Models\IntegrityRun;
+
+class IntegrityScanCompletedEvent
+{
+    use Dispatchable;
+
+    public function __construct(
+        public readonly IntegrityRun $run,
+    ) {}
+}

--- a/src/Events/LiveTrafficCapturedEvent.php
+++ b/src/Events/LiveTrafficCapturedEvent.php
@@ -42,7 +42,7 @@ class LiveTrafficCapturedEvent implements ShouldBroadcast
         // Realtime live-traffic broadcast is a premium feature. Free tier
         // can poll the /shield/live-traffic page on a timer; only paid
         // sites get the WebSocket push channel. Silently returns false
-        // on errors so a broken license check doesn't cascade — operators
+        // on errors so a broken license check doesn't cascade, operators
         // diagnose via /shield/license + /shield/webhook-deliveries.
         try {
             return \OzanKurt\Shield\Facades\Shield::isFeatureAvailable('realtime_live_traffic');

--- a/src/Firewall/Middleware/Bypass.php
+++ b/src/Firewall/Middleware/Bypass.php
@@ -42,7 +42,7 @@ class Bypass
     private function headerKeyMatches(Request $request): bool
     {
         // Read directly from env() rather than config() so this still works
-        // after `php artisan config:cache` — sensitive keys should not be cached.
+        // after `php artisan config:cache`, sensitive keys should not be cached.
         $expected = env('LS_BYPASS_KEY');
 
         if (! $expected) {

--- a/src/Http/Controllers/AclController.php
+++ b/src/Http/Controllers/AclController.php
@@ -2,7 +2,7 @@
 
 namespace OzanKurt\Shield\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 use OzanKurt\Shield\Models\Acl;
 

--- a/src/Http/Controllers/AuditLogController.php
+++ b/src/Http/Controllers/AuditLogController.php
@@ -2,7 +2,7 @@
 
 namespace OzanKurt\Shield\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 use OzanKurt\Shield\Models\AuditLog;
 use OzanKurt\Shield\Models\Lookups\AuditLogKind;

--- a/src/Http/Controllers/AuthLogsController.php
+++ b/src/Http/Controllers/AuthLogsController.php
@@ -2,7 +2,7 @@
 
 namespace OzanKurt\Shield\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 use OzanKurt\Shield\Models\AuthLog;
 

--- a/src/Http/Controllers/ComposerAuditController.php
+++ b/src/Http/Controllers/ComposerAuditController.php
@@ -2,7 +2,7 @@
 
 namespace OzanKurt\Shield\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 use OzanKurt\Shield\Models\Lookups\ScannerBackend;
 use OzanKurt\Shield\Models\ScannerFinding;

--- a/src/Http/Controllers/DashboardController.php
+++ b/src/Http/Controllers/DashboardController.php
@@ -2,7 +2,7 @@
 
 namespace OzanKurt\Shield\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use OzanKurt\Shield\Enums\IpEntryType;
 use OzanKurt\Shield\Http\Middleware\ShieldDashboardMiddleware;
 use OzanKurt\Shield\Models\Ip;

--- a/src/Http/Controllers/DiagnosticsController.php
+++ b/src/Http/Controllers/DiagnosticsController.php
@@ -2,7 +2,7 @@
 
 namespace OzanKurt\Shield\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use OzanKurt\Shield\Models\ScannerRun;
 use OzanKurt\Shield\Models\Signature;
 use OzanKurt\Shield\Services\Audit\EnvAuditor;

--- a/src/Http/Controllers/HoneypotController.php
+++ b/src/Http/Controllers/HoneypotController.php
@@ -2,7 +2,7 @@
 
 namespace OzanKurt\Shield\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 use OzanKurt\Shield\Models\Acl;
 use OzanKurt\Shield\Models\Lookups\AclAction;

--- a/src/Http/Controllers/IntegrityController.php
+++ b/src/Http/Controllers/IntegrityController.php
@@ -109,7 +109,7 @@ class IntegrityController extends Controller
             'uuid' => $r->uuid,
             'disk' => $r->disk,
             'status' => $lookups->name(IntegrityStatus::class, $r->status_id),
-            'severity' => $r->severity_id ? $lookups->name(LogLevel::class, $r->severity_id) : '—',
+            'severity' => $r->severity_id ? $lookups->name(LogLevel::class, $r->severity_id) : '-',
             'new' => $r->count_new,
             'modified' => $r->count_modified,
             'deleted' => $r->count_deleted,
@@ -150,7 +150,7 @@ class IntegrityController extends Controller
             'path' => $r->path,
             'change_type' => $lookups->name(IntegrityChangeType::class, $r->change_type_id),
             'compared_to' => $lookups->name(IntegrityComparisonBasis::class, $r->compared_to_id),
-            'severity' => $r->severity_id ? $lookups->name(LogLevel::class, $r->severity_id) : '—',
+            'severity' => $r->severity_id ? $lookups->name(LogLevel::class, $r->severity_id) : '-',
         ]);
 
         return response()->json([

--- a/src/Http/Controllers/IntegrityController.php
+++ b/src/Http/Controllers/IntegrityController.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace OzanKurt\Shield\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use OzanKurt\Shield\Models\IntegrityBaseline;
+use OzanKurt\Shield\Models\IntegrityChange;
+use OzanKurt\Shield\Models\IntegrityRun;
+use OzanKurt\Shield\Models\Lookups\IntegrityChangeType;
+use OzanKurt\Shield\Models\Lookups\IntegrityComparisonBasis;
+use OzanKurt\Shield\Models\Lookups\IntegrityStatus;
+use OzanKurt\Shield\Models\Lookups\LogLevel;
+use OzanKurt\Shield\Services\Integrity\IntegrityScanner;
+use OzanKurt\Shield\Services\Lookups\LookupResolver;
+
+class IntegrityController extends Controller
+{
+    public function index(LookupResolver $lookups)
+    {
+        $latestRun = IntegrityRun::query()->latest('id')->first();
+        $baseline = IntegrityBaseline::query()->latest('id')->first();
+
+        $stats = [
+            'latest_run' => $latestRun,
+            'latest_run_status' => $latestRun ? $lookups->name(IntegrityStatus::class, $latestRun->status_id) : null,
+            'total_runs' => IntegrityRun::count(),
+            'baseline' => $baseline,
+            'drift' => $latestRun?->count_vs_known_good ?? 0,
+            'disks' => array_keys((array) config('shield.integrity.disks', [])),
+        ];
+
+        return view('shield::dashboard.integrity.index', compact('stats'));
+    }
+
+    public function runs(Request $request, LookupResolver $lookups)
+    {
+        if ($request->get('mode') === 'dataTable') {
+            return $this->runsJson($request, $lookups);
+        }
+
+        return view('shield::dashboard.integrity.runs');
+    }
+
+    public function changes(Request $request, LookupResolver $lookups)
+    {
+        if ($request->get('mode') === 'dataTable') {
+            return $this->changesJson($request, $lookups);
+        }
+
+        return view('shield::dashboard.integrity.changes');
+    }
+
+    public function scan(Request $request, IntegrityScanner $scanner)
+    {
+        $disk = (string) $request->input('disk', 'app');
+        $run = $scanner->run($disk, 'manual');
+        $status = $run->status->name ?? 'unknown';
+
+        return response()->json([
+            'actions' => [
+                ['type' => 'toastr', 'data' => [
+                    'type' => $status === 'tamper_suspected' ? 'error' : 'success',
+                    'message' => "Integrity scan #{$run->id} [{$disk}]: {$status}.",
+                ]],
+                ['type' => 'reloadDataTable', 'data' => ['dataTableId' => 'integrityRunsTable']],
+            ],
+        ]);
+    }
+
+    public function bless(Request $request, IntegrityScanner $scanner)
+    {
+        $disk = (string) $request->input('disk', 'app');
+
+        try {
+            $baseline = $scanner->bless($disk);
+        } catch (\InvalidArgumentException $e) {
+            return response()->json([
+                'actions' => [
+                    ['type' => 'toastr', 'data' => ['type' => 'error', 'message' => $e->getMessage()]],
+                ],
+            ]);
+        }
+
+        return response()->json([
+            'actions' => [
+                ['type' => 'toastr', 'data' => [
+                    'type' => 'success',
+                    'message' => "Baseline approved for [{$disk}]: {$baseline->files_total} files.",
+                ]],
+            ],
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // JSON endpoints
+    // -------------------------------------------------------------------------
+
+    private function runsJson(Request $request, LookupResolver $lookups)
+    {
+        $query = IntegrityRun::query();
+        $total = $query->count();
+
+        $start = (int) $request->input('start', 0);
+        $length = (int) $request->input('length', 25);
+
+        $rows = $query->latest('id')->offset($start)->limit($length)->get()->map(fn ($r) => [
+            'id' => $r->id,
+            'uuid' => $r->uuid,
+            'disk' => $r->disk,
+            'status' => $lookups->name(IntegrityStatus::class, $r->status_id),
+            'severity' => $r->severity_id ? $lookups->name(LogLevel::class, $r->severity_id) : '—',
+            'new' => $r->count_new,
+            'modified' => $r->count_modified,
+            'deleted' => $r->count_deleted,
+            'vs_known_good' => $r->count_vs_known_good,
+            'files_total' => $r->files_total,
+            'started_at' => (string) $r->started_at,
+        ]);
+
+        return response()->json([
+            'draw' => (int) $request->input('draw'),
+            'recordsTotal' => $total,
+            'recordsFiltered' => $total,
+            'data' => $rows,
+        ]);
+    }
+
+    private function changesJson(Request $request, LookupResolver $lookups)
+    {
+        $query = IntegrityChange::query();
+
+        if ($runId = $request->input('run_id')) {
+            $query->where('integrity_run_id', (int) $runId);
+        }
+
+        $total = $query->count();
+
+        if ($search = $request->input('search.value')) {
+            $query->where('path', 'like', "%{$search}%");
+        }
+
+        $filtered = $query->count();
+        $start = (int) $request->input('start', 0);
+        $length = (int) $request->input('length', 25);
+
+        $rows = $query->orderByDesc('severity_id')->orderBy('id')->offset($start)->limit($length)->get()->map(fn ($r) => [
+            'id' => $r->id,
+            'run' => $r->integrity_run_id,
+            'path' => $r->path,
+            'change_type' => $lookups->name(IntegrityChangeType::class, $r->change_type_id),
+            'compared_to' => $lookups->name(IntegrityComparisonBasis::class, $r->compared_to_id),
+            'severity' => $r->severity_id ? $lookups->name(LogLevel::class, $r->severity_id) : '—',
+        ]);
+
+        return response()->json([
+            'draw' => (int) $request->input('draw'),
+            'recordsTotal' => $total,
+            'recordsFiltered' => $filtered,
+            'data' => $rows,
+        ]);
+    }
+}

--- a/src/Http/Controllers/LicenseController.php
+++ b/src/Http/Controllers/LicenseController.php
@@ -2,7 +2,7 @@
 
 namespace OzanKurt\Shield\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use OzanKurt\Shield\Services\Premium\CentralClient;
@@ -34,7 +34,7 @@ class LicenseController extends Controller
 
         $flash = match ($state['state'] ?? null) {
             'valid' => 'License refreshed successfully.',
-            'grace' => 'Central unreachable — grace period active until ' . ($state['grace_until'] ?? 'unknown') . '.',
+            'grace' => 'Central unreachable, grace period active until ' . ($state['grace_until'] ?? 'unknown') . '.',
             'invalid' => 'License is invalid: ' . ($state['reason'] ?? 'unknown reason') . '.',
             'no_key' => 'No license key configured. Add LS_PREMIUM_LICENSE_KEY to .env.',
             default => 'License refresh completed.',
@@ -72,7 +72,7 @@ class LicenseController extends Controller
         ]);
 
         $status = match (true) {
-            $result->ok() => "Connectivity OK — Central returned HTTP {$result->httpStatus}.",
+            $result->ok() => "Connectivity OK, Central returned HTTP {$result->httpStatus}.",
             $result->outcome === 'skipped' => "Test skipped: {$result->error}.",
             default => "Connectivity failed (status={$result->httpStatus}, reason={$result->error}). See /shield/webhook-deliveries for the captured attempt.",
         };

--- a/src/Http/Controllers/LiveTrafficController.php
+++ b/src/Http/Controllers/LiveTrafficController.php
@@ -2,7 +2,7 @@
 
 namespace OzanKurt\Shield\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 use OzanKurt\Shield\Models\Lookups\ActionKind;
 use OzanKurt\Shield\Models\LiveTrafficRecord;

--- a/src/Http/Controllers/LogsController.php
+++ b/src/Http/Controllers/LogsController.php
@@ -2,7 +2,7 @@
 
 namespace OzanKurt\Shield\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 use OzanKurt\Shield\Models\Log;
 

--- a/src/Http/Controllers/ScannerController.php
+++ b/src/Http/Controllers/ScannerController.php
@@ -2,7 +2,7 @@
 
 namespace OzanKurt\Shield\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 use OzanKurt\Shield\Models\Lookups\ScannerFindingStatus;
 use OzanKurt\Shield\Models\Lookups\ScannerStatus;

--- a/src/Http/Controllers/ThreatFeedController.php
+++ b/src/Http/Controllers/ThreatFeedController.php
@@ -2,7 +2,7 @@
 
 namespace OzanKurt\Shield\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use OzanKurt\Shield\Contracts\ThreatFeedProvider;
 use OzanKurt\Shield\Models\AuditLog;
 use OzanKurt\Shield\Models\Lookups\AuditLogKind;
@@ -32,8 +32,8 @@ class ThreatFeedController extends Controller
                 'name' => $provider->name(),
                 'label' => $provider->label(),
                 'available' => $provider->isAvailable(),
-                'last_run' => (string) ($latest?->created_at ?? '—'),
-                'last_status' => $latest?->description ?? '—',
+                'last_run' => (string) ($latest?->created_at ?? '-'),
+                'last_status' => $latest?->description ?? '-',
             ];
         }
 

--- a/src/Http/Controllers/WafRulesController.php
+++ b/src/Http/Controllers/WafRulesController.php
@@ -2,7 +2,7 @@
 
 namespace OzanKurt\Shield\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 use OzanKurt\Shield\Models\Lookups\LogLevel;

--- a/src/Http/Controllers/WebhookDeliveriesController.php
+++ b/src/Http/Controllers/WebhookDeliveriesController.php
@@ -2,7 +2,7 @@
 
 namespace OzanKurt\Shield\Http\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use OzanKurt\Shield\Jobs\ForwardAuditToCentralJob;
@@ -49,7 +49,7 @@ class WebhookDeliveriesController extends Controller
         $delivery = WebhookDelivery::query()->findOrFail($id);
 
         if ($delivery->isPending()) {
-            return back()->with('status', "Delivery #{$id} is still pending — wait for it to finish.");
+            return back()->with('status', "Delivery #{$id} is still pending, wait for it to finish.");
         }
 
         if ($delivery->operation !== 'webhook_ingest') {
@@ -57,12 +57,12 @@ class WebhookDeliveriesController extends Controller
         }
 
         if (! $delivery->audit_log_id) {
-            return back()->with('status', "Delivery #{$id} has no linked audit log — cannot reconstruct payload for retry.");
+            return back()->with('status', "Delivery #{$id} has no linked audit log, cannot reconstruct payload for retry.");
         }
 
         $entry = AuditLog::query()->find($delivery->audit_log_id);
         if (! $entry) {
-            return back()->with('status', "Audit log #{$delivery->audit_log_id} no longer exists — retry impossible.");
+            return back()->with('status', "Audit log #{$delivery->audit_log_id} no longer exists, retry impossible.");
         }
 
         ForwardAuditToCentralJob::dispatch([

--- a/src/Http/Middleware/LiveTrafficCapture.php
+++ b/src/Http/Middleware/LiveTrafficCapture.php
@@ -13,7 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Throwable;
 
 /**
- * Terminable middleware — records the request after the response is sent
+ * Terminable middleware, records the request after the response is sent
  * so the capture cost stays off the request path.
  *
  * Sampling:

--- a/src/Integrations/SpatieMediaLibrary/MediaScanListener.php
+++ b/src/Integrations/SpatieMediaLibrary/MediaScanListener.php
@@ -54,7 +54,7 @@ class MediaScanListener
                 ],
             ]);
 
-            throw new RuntimeException('Shield: media file rejected — suspicious content detected.');
+            throw new RuntimeException('Shield: media file rejected, suspicious content detected.');
         }
     }
 

--- a/src/Jobs/ForwardAuditToCentralJob.php
+++ b/src/Jobs/ForwardAuditToCentralJob.php
@@ -20,7 +20,7 @@ use OzanKurt\Shield\Services\Premium\CentralClient;
  *   - 5xx (Central having a bad day)                          → retry
  *   - Connection failure (timeout, DNS, refused)              → retry
  *
- * Exponential backoff with jitter (configurable via $backoff()) — 30s,
+ * Exponential backoff with jitter (configurable via $backoff()), 30s,
  * 90s, 270s on default 3-attempt setting. Total max delay ~6 minutes
  * before exhaustion, well within reason for transient Central outages.
  *
@@ -92,7 +92,7 @@ class ForwardAuditToCentralJob implements ShouldQueue
 
             // Find the most-recent delivery row + update on the instance.
             // Eloquent's update() against a query builder ignores latest()
-            // and limit() — running `->update()` after `->latest()->limit(1)`
+            // and limit(), running `->update()` after `->latest()->limit(1)`
             // generates UPDATE ... WHERE without ORDER/LIMIT in most drivers,
             // which would rewrite EVERY delivery row for this audit event
             // and destroy the per-attempt history.

--- a/src/Listeners/IntegrityScanCompletedListener.php
+++ b/src/Listeners/IntegrityScanCompletedListener.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace OzanKurt\Shield\Listeners;
+
+use OzanKurt\Shield\Events\IntegrityScanCompletedEvent;
+use OzanKurt\Shield\Notifications\IntegrityScanCompletedNotification;
+use OzanKurt\Shield\Notifications\Notifiable;
+use Throwable;
+
+/**
+ * Sends the integrity summary card. Thin by design (no ListenerHelper: integrity
+ * scans run in the console with no HTTP request / auth-log context).
+ *
+ * Suppression: when suppress_when_no_changes is on and the per-run delta is
+ * empty, ordinary completed runs are silent. Security/operational state events
+ * (tamper_suspected, baseline_established, failed, aborted_limit) ALWAYS notify,
+ * regardless of the delta.
+ */
+class IntegrityScanCompletedListener
+{
+    private const SECURITY_EVENT_STATUSES = [
+        'tamper_suspected',
+        'baseline_established',
+        'failed',
+        'aborted_limit',
+    ];
+
+    public function handle(IntegrityScanCompletedEvent $event): void
+    {
+        if (! config('shield.notifications.integrity_changed.enabled', false)) {
+            return;
+        }
+
+        $run = $event->run;
+        $status = $run->status->name ?? '';
+        $isSecurityEvent = in_array($status, self::SECURITY_EVENT_STATUSES, true);
+
+        $delta = (int) $run->count_new + (int) $run->count_modified + (int) $run->count_deleted;
+        $suppress = (bool) config('shield.integrity.notify.suppress_when_no_changes', true);
+
+        if (! $isSecurityEvent && $suppress && $delta === 0) {
+            return;
+        }
+
+        try {
+            (new Notifiable)->notify(new IntegrityScanCompletedNotification($run));
+        } catch (Throwable $e) {
+            report($e);
+        }
+    }
+}

--- a/src/Models/IntegrityBaseline.php
+++ b/src/Models/IntegrityBaseline.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace OzanKurt\Shield\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use OzanKurt\Shield\Concerns\HasUserstamps;
+use OzanKurt\Shield\Concerns\HasUuid;
+
+class IntegrityBaseline extends Model
+{
+    use HasUuid, HasUserstamps, SoftDeletes;
+
+    protected $table = 'ls_integrity_baselines';
+
+    protected $fillable = [
+        'uuid', 'disk', 'scope_fingerprint', 'root_hash', 'artifact_path',
+        'algo', 'files_total', 'signed', 'blessed_at',
+    ];
+
+    protected $casts = [
+        'files_total' => 'integer',
+        'signed' => 'boolean',
+        'blessed_at' => 'datetime',
+    ];
+
+    public function __construct(array $attributes = [])
+    {
+        if (! isset($this->connection)) {
+            $this->setConnection(config('shield.database.connection'));
+        }
+        parent::__construct($attributes);
+    }
+}

--- a/src/Models/IntegrityChange.php
+++ b/src/Models/IntegrityChange.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace OzanKurt\Shield\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use OzanKurt\Shield\Concerns\HasUserstamps;
+use OzanKurt\Shield\Concerns\HasUuid;
+use OzanKurt\Shield\Models\Lookups\IntegrityChangeType;
+use OzanKurt\Shield\Models\Lookups\IntegrityComparisonBasis;
+use OzanKurt\Shield\Models\Lookups\LogLevel;
+
+class IntegrityChange extends Model
+{
+    use HasUuid, HasUserstamps, SoftDeletes;
+
+    protected $table = 'ls_integrity_changes';
+
+    protected $fillable = [
+        'uuid', 'correlation_id', 'integrity_run_id', 'change_type_id', 'compared_to_id',
+        'severity_id', 'path', 'old_hash', 'new_hash', 'size_bytes', 'file_mtime', 'symlink_target',
+    ];
+
+    protected $casts = [
+        'file_mtime' => 'datetime',
+        'size_bytes' => 'integer',
+    ];
+
+    public function __construct(array $attributes = [])
+    {
+        if (! isset($this->connection)) {
+            $this->setConnection(config('shield.database.connection'));
+        }
+        parent::__construct($attributes);
+    }
+
+    public function run()
+    {
+        return $this->belongsTo(IntegrityRun::class, 'integrity_run_id');
+    }
+
+    public function changeType()
+    {
+        return $this->belongsTo(IntegrityChangeType::class, 'change_type_id');
+    }
+
+    public function comparedTo()
+    {
+        return $this->belongsTo(IntegrityComparisonBasis::class, 'compared_to_id');
+    }
+
+    public function severity()
+    {
+        return $this->belongsTo(LogLevel::class, 'severity_id');
+    }
+}

--- a/src/Models/IntegrityRun.php
+++ b/src/Models/IntegrityRun.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace OzanKurt\Shield\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use OzanKurt\Shield\Concerns\HasUserstamps;
+use OzanKurt\Shield\Concerns\HasUuid;
+use OzanKurt\Shield\Models\Lookups\IntegrityStatus;
+use OzanKurt\Shield\Models\Lookups\LogLevel;
+use OzanKurt\Shield\Models\Lookups\ScannerTrigger;
+
+class IntegrityRun extends Model
+{
+    use HasUuid, HasUserstamps, SoftDeletes;
+
+    protected $table = 'ls_integrity_runs';
+
+    protected $fillable = [
+        'uuid', 'correlation_id', 'status_id', 'trigger_id', 'severity_id',
+        'disk', 'scope_fingerprint', 'baseline_root_hash', 'current_root_hash',
+        'files_total', 'files_hashed', 'files_size_only', 'files_unreadable', 'files_excluded',
+        'count_new', 'count_modified', 'count_deleted', 'count_scope_changed', 'count_vs_known_good',
+        'started_at', 'finished_at', 'duration_ms', 'error_message',
+    ];
+
+    protected $casts = [
+        'started_at' => 'datetime',
+        'finished_at' => 'datetime',
+        'files_total' => 'integer',
+        'files_hashed' => 'integer',
+        'files_size_only' => 'integer',
+        'files_unreadable' => 'integer',
+        'files_excluded' => 'integer',
+        'count_new' => 'integer',
+        'count_modified' => 'integer',
+        'count_deleted' => 'integer',
+        'count_scope_changed' => 'integer',
+        'count_vs_known_good' => 'integer',
+        'duration_ms' => 'integer',
+    ];
+
+    public function __construct(array $attributes = [])
+    {
+        if (! isset($this->connection)) {
+            $this->setConnection(config('shield.database.connection'));
+        }
+        parent::__construct($attributes);
+    }
+
+    public function status()
+    {
+        return $this->belongsTo(IntegrityStatus::class, 'status_id');
+    }
+
+    public function trigger()
+    {
+        return $this->belongsTo(ScannerTrigger::class, 'trigger_id');
+    }
+
+    public function severity()
+    {
+        return $this->belongsTo(LogLevel::class, 'severity_id');
+    }
+
+    public function changes()
+    {
+        return $this->hasMany(IntegrityChange::class, 'integrity_run_id');
+    }
+}

--- a/src/Models/Lookups/IntegrityChangeType.php
+++ b/src/Models/Lookups/IntegrityChangeType.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OzanKurt\Shield\Models\Lookups;
+
+class IntegrityChangeType extends Lookup
+{
+    protected $table = 'ls_integrity_change_types';
+}

--- a/src/Models/Lookups/IntegrityComparisonBasis.php
+++ b/src/Models/Lookups/IntegrityComparisonBasis.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OzanKurt\Shield\Models\Lookups;
+
+class IntegrityComparisonBasis extends Lookup
+{
+    protected $table = 'ls_integrity_comparison_bases';
+}

--- a/src/Models/Lookups/IntegrityStatus.php
+++ b/src/Models/Lookups/IntegrityStatus.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace OzanKurt\Shield\Models\Lookups;
+
+class IntegrityStatus extends Lookup
+{
+    protected $table = 'ls_integrity_statuses';
+}

--- a/src/Models/WebhookDelivery.php
+++ b/src/Models/WebhookDelivery.php
@@ -13,12 +13,12 @@ use OzanKurt\Shield\Concerns\HasUuid;
  *
  *   dispatch → pending  (job picked up, about to POST)
  *   pending → success   (2xx response)
- *   pending → failure   (4xx — permanent, no retry)
- *   pending → failure   (5xx or connection error — retried by queue)
+ *   pending → failure   (4xx, permanent, no retry)
+ *   pending → failure   (5xx or connection error, retried by queue)
  *   pending → exhausted (all retries failed; job will not retry)
  *   pending → skipped   (no license / no URL / circuit open)
  *
- * Updates are append-only to a single row per attempt — the queue's
+ * Updates are append-only to a single row per attempt, the queue's
  * retry counter creates a new row for each retry, so the row trail
  * tells the full story of one logical event's delivery.
  */

--- a/src/Notifications/AttackDetectedNotification.php
+++ b/src/Notifications/AttackDetectedNotification.php
@@ -22,11 +22,6 @@ class AttackDetectedNotification extends Notification implements ShouldQueue
     public $log;
 
     /**
-     * The notification config.
-     */
-    public array $notifications;
-
-    /**
      * Create a notification instance.
      *
      * @param  object  $log
@@ -34,21 +29,20 @@ class AttackDetectedNotification extends Notification implements ShouldQueue
     public function __construct($log)
     {
         $this->log = $log;
-        $this->notifications = config('shield.notifications');
     }
 
     /**
      * Get the notification's channels.
      *
      * @param  mixed  $notifiable
-     * @return array|string
+     * @return array
      */
-    public function via($notifiable)
+    public function via($notifiable): array
     {
         $channels = [];
 
-        foreach ($this->notifications as $channel => $settings) {
-            if (empty($settings['enabled'])) {
+        foreach (config('shield.notifications.attack_detected.channels', []) as $channel) {
+            if (! config("shield.notification_channels.{$channel}.enabled")) {
                 continue;
             }
 
@@ -59,14 +53,22 @@ class AttackDetectedNotification extends Notification implements ShouldQueue
     }
 
     /**
-     * Get the notification's queues.
-     * @return array|string
+     * Map each configured channel to the queue it should be sent on.
+     *
+     * Keyed by the same channel identifier `via()` returns (the channel class
+     * for Discord, the channel name otherwise) so Laravel can resolve it.
+     *
+     * @return array
      */
     public function viaQueues(): array
     {
-        return array_map(function ($channel) {
-            return $channel['queue'] ?? 'default';
-        }, $this->notifications);
+        $queues = [];
+
+        foreach (config('shield.notifications.attack_detected.channels', []) as $channel) {
+            $queues[$this->getChannelClass($channel)] = config("shield.notification_channels.{$channel}.queue", 'default');
+        }
+
+        return $queues;
     }
 
     /**
@@ -91,7 +93,7 @@ class AttackDetectedNotification extends Notification implements ShouldQueue
         ]);
 
         return (new MailMessage)
-            ->from($this->notifications['mail']['from'], $this->notifications['mail']['name'])
+            ->from(config('shield.notification_channels.mail.from'), config('shield.notification_channels.mail.name'))
             ->subject($subject)
             ->line($message);
     }
@@ -110,8 +112,8 @@ class AttackDetectedNotification extends Notification implements ShouldQueue
 
         return (new SlackMessage)
             ->error()
-            ->from($this->notifications['slack']['from'], $this->notifications['slack']['emoji'])
-            ->to($this->notifications['slack']['channel'])
+            ->from(config('shield.notification_channels.slack.from'), config('shield.notification_channels.slack.emoji'))
+            ->to(config('shield.notification_channels.slack.channel'))
             ->content($message)
             ->attachment(function ($attachment) {
                 $attachment->fields([
@@ -129,29 +131,24 @@ class AttackDetectedNotification extends Notification implements ShouldQueue
             'domain' => request()->getHttpHost(),
         ]);
 
-        try {
-            $url = $this->log->url;
-            $url = preg_replace('/^https?:\/\/[^\/]+/', '', $url);
+        $url = preg_replace('/^https?:\/\/[^\/]+/', '', (string) $this->log->url);
 
-            return (new DiscordMessage)
-                ->from(config('shield.notifications.discord.from'), config('shield.notifications.discord.from_img'))
-                ->url(config('shield.notifications.discord.route'))
-                ->title(config('shield.notifications.discord.title'))
-                ->description($body)
-                ->fields([
-                    'IP' => $this->log->ip,
-                    'Type' => ucfirst($this->log->middleware),
-                    'User ID' => $this->log->user_id === 0 ? 'Guest' : $this->log->user_id,
-                ], true)
-                ->fields([
-                    'URL' => $url,
-                ], false)
-                ->timestamp(now())
-                ->footer(config('shield.notifications.discord.footer'), config('shield.notifications.discord.footer_img'))
-                ->warning();
-        } catch (\Throwable $exception) {
-            report($exception);
-        }
+        return (new DiscordMessage)
+            ->from(config('shield.notification_channels.discord.from'), config('shield.notification_channels.discord.from_img'))
+            ->url(config('shield.notification_channels.discord.route'))
+            ->title(config('shield.notification_channels.discord.title'))
+            ->description($body)
+            ->fields([
+                'IP' => $this->log->ip,
+                'Type' => ucfirst($this->log->middleware),
+                'User ID' => $this->log->user_id === 0 ? 'Guest' : $this->log->user_id,
+            ], true)
+            ->fields([
+                'URL' => $url,
+            ], false)
+            ->timestamp(now())
+            ->footer(config('shield.notification_channels.discord.footer'), config('shield.notification_channels.discord.footer_img'))
+            ->warning();
     }
 
     public function getChannelClass(string $channel): string

--- a/src/Notifications/Channels/Discord/DiscordMessage.php
+++ b/src/Notifications/Channels/Discord/DiscordMessage.php
@@ -9,6 +9,7 @@ class DiscordMessage
     public const COLOR_SUCCESS = '0b6623';
     public const COLOR_WARNING = 'fD6a02';
     public const COLOR_ERROR = 'e32929';
+    public const COLOR_DEFAULT = '6c757d'; // gray, used when no severity color is set
 
     protected string $username = 'Laravel Security';
 
@@ -114,7 +115,7 @@ class DiscordMessage
     public function toArray(): array
     {
         return [
-            'username' => $this->username ?? 'Laravel Backup',
+            'username' => $this->username,
             'avatar_url' => $this->avatarUrl,
             'embeds' => [
                 [
@@ -123,12 +124,12 @@ class DiscordMessage
                     'type' => 'rich',
                     'description' => $this->description,
                     'fields' => $this->fields,
-                    'color' => hexdec($this->color),
+                    'color' => hexdec($this->color ?? self::COLOR_DEFAULT),
                     'footer' => [
                         'text' => $this->footer ?? '',
-                        'icon_url' => $this->footerImg ?? '',
+                        'icon_url' => $this->footerUrl ?? '',
                     ],
-                    'timestamp' => $this->timestamp ?? now(),
+                    'timestamp' => $this->timestamp ?? now()->toIso8601String(),
                 ],
             ],
         ];

--- a/src/Notifications/Channels/Discord/DiscordMessage.php
+++ b/src/Notifications/Channels/Discord/DiscordMessage.php
@@ -99,6 +99,14 @@ class DiscordMessage
         return $this;
     }
 
+    /** Set an arbitrary embed colour (6-hex-digit string, no leading #). */
+    public function color(string $hex): self
+    {
+        $this->color = $hex;
+
+        return $this;
+    }
+
     public function fields(array $fields, bool $inline = true): self
     {
         foreach ($fields as $label => $value) {

--- a/src/Notifications/FailedLoginNotification.php
+++ b/src/Notifications/FailedLoginNotification.php
@@ -5,106 +5,144 @@ namespace OzanKurt\Shield\Notifications;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
 use OzanKurt\Shield\Models\AuthLog;
+use OzanKurt\Shield\Notifications\Channels\Discord\DiscordChannel;
+use OzanKurt\Shield\Notifications\Channels\Discord\DiscordMessage;
 
 class FailedLoginNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    public array $config;
+    /**
+     * The configured event key this notification is delivered under.
+     */
+    protected string $event = 'failed_login';
 
     public function __construct(
         public AuthLog $authLog
-    )
-    {
-        $this->config = config('shield.notifications.successful_login');
+    ) {
     }
 
     /**
      * Get the notification's channels.
      *
-     * @param mixed $notifiable
+     * @param  mixed  $notifiable
      * @return array
      */
     public function via($notifiable): array
     {
         $channels = [];
 
-        foreach ($this->config['channels'] as $channel => $settings) {
-            if (empty($settings['enabled'])) {
+        foreach (config("shield.notifications.{$this->event}.channels", []) as $channel) {
+            if (! config("shield.notification_channels.{$channel}.enabled")) {
                 continue;
             }
 
-            $channels[] = $channel;
+            $channels[] = $this->getChannelClass($channel);
         }
 
         return $channels;
     }
 
     /**
-     * Get the notification's queues.
+     * Map each configured channel to the queue it should be sent on.
+     *
+     * Keyed by the same channel identifier `via()` returns (the channel class
+     * for Discord, the channel name otherwise) so Laravel can resolve it.
      *
      * @return array
      */
     public function viaQueues(): array
     {
-        return array_map(static function ($channel) {
-            return $channel['queue'] ?? 'default';
-        }, $this->$this->config['channels']);
+        $queues = [];
+
+        foreach (config("shield.notifications.{$this->event}.channels", []) as $channel) {
+            $queues[$this->getChannelClass($channel)] = config("shield.notification_channels.{$channel}.queue", 'default');
+        }
+
+        return $queues;
     }
 
     /**
      * Build the mail representation of the notification.
      *
-     * @param mixed $notifiable
+     * @param  mixed  $notifiable
      * @return \Illuminate\Notifications\Messages\MailMessage
      */
     public function toMail($notifiable)
     {
         $domain = request()->getHttpHost();
 
-        $subject = trans('shield::notifications.mail.subject', [
+        $subject = trans('shield::notifications.failed_login.mail.subject', [
             'domain' => $domain,
         ]);
 
-        $message = trans('shield::notifications.mail.message', [
+        $message = trans('shield::notifications.failed_login.mail.message', [
             'domain' => $domain,
-            'middleware' => ucfirst($this->log->middleware),
-            'ip' => $this->log->ip,
-            'url' => $this->log->url,
         ]);
 
         return (new MailMessage)
-            ->from($this->notifications['mail']['from'], $this->notifications['mail']['name'])
+            ->from(config('shield.notification_channels.mail.from'), config('shield.notification_channels.mail.name'))
             ->subject($subject)
-            ->line($message);
+            ->line($message)
+            ->line('Email: '.$this->authLog->email)
+            ->line('IP: '.$this->authLog->ip);
     }
 
     /**
      * Get the Slack representation of the notification.
      *
-     * @param mixed $notifiable
+     * @param  mixed  $notifiable
      * @return SlackMessage
      */
     public function toSlack($notifiable)
     {
-        $message = trans('shield::notifications.slack.message', [
+        $message = trans('shield::notifications.failed_login.slack.message', [
             'domain' => request()->getHttpHost(),
         ]);
 
         return (new SlackMessage)
             ->error()
-            ->from($this->notifications['slack']['from'], $this->notifications['slack']['emoji'])
-            ->to($this->notifications['slack']['channel'])
+            ->from(config('shield.notification_channels.slack.from'), config('shield.notification_channels.slack.emoji'))
+            ->to(config('shield.notification_channels.slack.channel'))
             ->content($message)
             ->attachment(function ($attachment) {
                 $attachment->fields([
-                    'IP' => $this->log->ip,
-                    'Type' => ucfirst($this->log->middleware),
-                    'User ID' => $this->log->user_id,
-                    'URL' => $this->log->url,
+                    'Email' => $this->authLog->email,
+                    'IP' => $this->authLog->ip,
+                    'User ID' => $this->authLog->user_id ?? 'Guest',
                 ]);
             });
+    }
+
+    public function toDiscord()
+    {
+        $body = trans('shield::notifications.failed_login.discord.message', [
+            'domain' => request()->getHttpHost(),
+        ]);
+
+        return (new DiscordMessage)
+            ->from(config('shield.notification_channels.discord.from'), config('shield.notification_channels.discord.from_img'))
+            ->url(config('shield.notification_channels.discord.route'))
+            ->title(config('shield.notification_channels.discord.title'))
+            ->description($body)
+            ->fields([
+                'Email' => $this->authLog->email,
+                'IP' => $this->authLog->ip,
+                'User ID' => $this->authLog->user_id ?? 'Guest',
+            ], true)
+            ->timestamp(now())
+            ->footer(config('shield.notification_channels.discord.footer'), config('shield.notification_channels.discord.footer_img'))
+            ->error();
+    }
+
+    public function getChannelClass(string $channel): string
+    {
+        return match ($channel) {
+            'discord' => DiscordChannel::class,
+            default => $channel,
+        };
     }
 }

--- a/src/Notifications/IntegrityScanCompletedNotification.php
+++ b/src/Notifications/IntegrityScanCompletedNotification.php
@@ -64,7 +64,7 @@ class IntegrityScanCompletedNotification extends Notification implements ShouldQ
     {
         $mail = (new MailMessage)
             ->from(config('shield.notification_channels.mail.from'), config('shield.notification_channels.mail.name'))
-            ->subject($this->title() . ' — ' . $this->summary());
+            ->subject($this->title() . ' - ' . $this->summary());
 
         $mail->line('**' . $this->summary() . '**');
 
@@ -193,11 +193,22 @@ class IntegrityScanCompletedNotification extends Notification implements ShouldQ
             ->all();
     }
 
+    private function disclosePaths(): bool
+    {
+        return (bool) config('shield.integrity.notify.disclose_paths_to_external_channels', true);
+    }
+
     private function discordBlock(string $type): string
     {
+        if (! $this->disclosePaths()) {
+            $n = $this->count($type);
+
+            return $n > 0 ? "{$n} change(s), view in dashboard" : '-';
+        }
+
         $paths = $this->pathsFor($type);
         if (empty($paths)) {
-            return '—';
+            return '-';
         }
 
         $text = implode("\n", array_map(fn ($p) => '`' . $p . '`', $paths));
@@ -212,9 +223,15 @@ class IntegrityScanCompletedNotification extends Notification implements ShouldQ
 
     private function slackBlock(string $type): string
     {
+        if (! $this->disclosePaths()) {
+            $n = $this->count($type);
+
+            return $n > 0 ? "{$n} change(s), view in dashboard" : '-';
+        }
+
         $paths = $this->pathsFor($type);
         if (empty($paths)) {
-            return '—';
+            return '-';
         }
 
         $text = implode("\n", $paths);

--- a/src/Notifications/IntegrityScanCompletedNotification.php
+++ b/src/Notifications/IntegrityScanCompletedNotification.php
@@ -1,0 +1,227 @@
+<?php
+
+namespace OzanKurt\Shield\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Notifications\Notification;
+use OzanKurt\Shield\Models\IntegrityChange;
+use OzanKurt\Shield\Models\IntegrityRun;
+use OzanKurt\Shield\Models\Lookups\IntegrityChangeType;
+use OzanKurt\Shield\Models\Lookups\IntegrityComparisonBasis;
+use OzanKurt\Shield\Notifications\Channels\Discord\DiscordChannel;
+use OzanKurt\Shield\Notifications\Channels\Discord\DiscordMessage;
+use OzanKurt\Shield\Services\Integrity\SeverityColor;
+
+/**
+ * The "file integrity scan summary" card: New / Modified / Deleted file groups
+ * (per-run delta) plus a known-good drift line, routed to mail / Slack / Discord.
+ *
+ * Built from bounded queries + the run's persisted counts, never by hydrating
+ * the full change set, so a deploy that changes thousands of files cannot OOM
+ * the worker rendering the card.
+ */
+class IntegrityScanCompletedNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        public IntegrityRun $run
+    ) {}
+
+    public function via($notifiable): array
+    {
+        $channels = [];
+
+        foreach (config('shield.notifications.integrity_changed.channels', []) as $channel) {
+            if (! config("shield.notification_channels.{$channel}.enabled")) {
+                continue;
+            }
+
+            $channels[] = $this->getChannelClass($channel);
+        }
+
+        return $channels;
+    }
+
+    public function viaQueues(): array
+    {
+        $queues = [];
+
+        foreach (config('shield.notifications.integrity_changed.channels', []) as $channel) {
+            $queues[$this->getChannelClass($channel)] = config(
+                "shield.notification_channels.{$channel}.queue",
+                config('shield.integrity.queue', 'default')
+            );
+        }
+
+        return $queues;
+    }
+
+    public function toMail($notifiable): MailMessage
+    {
+        $mail = (new MailMessage)
+            ->from(config('shield.notification_channels.mail.from'), config('shield.notification_channels.mail.name'))
+            ->subject($this->title() . ' — ' . $this->summary());
+
+        $mail->line('**' . $this->summary() . '**');
+
+        if ($this->driftLine()) {
+            $mail->line($this->driftLine());
+        }
+
+        foreach (['new' => 'New', 'modified' => 'Modified', 'deleted' => 'Deleted'] as $type => $label) {
+            $count = $this->count($type);
+            if ($count === 0) {
+                continue;
+            }
+            $mail->line("**{$label} ({$count}):**");
+            foreach ($this->pathsFor($type) as $path) {
+                $mail->line('- ' . $path);
+            }
+            if (($more = $count - count($this->pathsFor($type))) > 0) {
+                $mail->line("+{$more} more");
+            }
+        }
+
+        return $mail;
+    }
+
+    public function toSlack($notifiable): SlackMessage
+    {
+        return (new SlackMessage)
+            ->from(config('shield.notification_channels.slack.from'), config('shield.notification_channels.slack.emoji'))
+            ->to(config('shield.notification_channels.slack.channel'))
+            ->content($this->title() . "\n" . $this->summary() . ($this->driftLine() ? "\n" . $this->driftLine() : ''))
+            ->attachment(function ($attachment) {
+                $attachment->fields([
+                    'New' => $this->slackBlock('new'),
+                    'Modified' => $this->slackBlock('modified'),
+                    'Deleted' => $this->slackBlock('deleted'),
+                ]);
+            });
+    }
+
+    public function toDiscord(): DiscordMessage
+    {
+        $message = (new DiscordMessage)
+            ->from(config('shield.notification_channels.discord.from'), config('shield.notification_channels.discord.from_img'))
+            ->url(config('shield.notification_channels.discord.route'))
+            ->title($this->title())
+            ->description($this->summary() . ($this->driftLine() ? "\n" . $this->driftLine() : ''))
+            ->fields(['New (' . $this->count('new') . ')' => $this->discordBlock('new')], false)
+            ->fields(['Modified (' . $this->count('modified') . ')' => $this->discordBlock('modified')], false)
+            ->fields(['Deleted (' . $this->count('deleted') . ')' => $this->discordBlock('deleted')], false)
+            ->timestamp($this->run->started_at ?? now())
+            ->footer(config('shield.notification_channels.discord.footer'), config('shield.notification_channels.discord.footer_img'))
+            ->color(SeverityColor::hex($this->run->severity->name ?? 'info'));
+
+        return $message;
+    }
+
+    public function getChannelClass(string $channel): string
+    {
+        return match ($channel) {
+            'discord' => DiscordChannel::class,
+            default => $channel,
+        };
+    }
+
+    private function title(): string
+    {
+        $tz = (string) config('shield.integrity.notify.timezone', 'UTC');
+        $ts = ($this->run->started_at ?? now())->copy()->setTimezone($tz)->format('Y-m-d H:i') . ' ' . $tz;
+
+        return trans('shield::notifications.integrity_changed.title', [
+            'disk' => $this->run->disk,
+            'time' => $ts,
+        ]);
+    }
+
+    private function summary(): string
+    {
+        return trans('shield::notifications.integrity_changed.summary', [
+            'new' => $this->count('new'),
+            'modified' => $this->count('modified'),
+            'deleted' => $this->count('deleted'),
+            'total' => (int) $this->run->files_total,
+        ]);
+    }
+
+    private function driftLine(): ?string
+    {
+        $drift = (int) $this->run->count_vs_known_good;
+        if ($drift <= 0) {
+            return null;
+        }
+
+        return trans('shield::notifications.integrity_changed.drift', ['count' => $drift]);
+    }
+
+    private function count(string $type): int
+    {
+        return (int) match ($type) {
+            'new' => $this->run->count_new,
+            'modified' => $this->run->count_modified,
+            'deleted' => $this->run->count_deleted,
+            default => 0,
+        };
+    }
+
+    /** @return string[] up to max_paths_per_group paths for the per-run delta, highest severity first */
+    private function pathsFor(string $changeType): array
+    {
+        $limit = (int) config('shield.integrity.notify.max_paths_per_group', 15);
+
+        $changeTypeId = IntegrityChangeType::where('name', $changeType)->value('id');
+        $deltaId = IntegrityComparisonBasis::where('name', 'last_run')->value('id');
+
+        if ($changeTypeId === null || $deltaId === null) {
+            return [];
+        }
+
+        return IntegrityChange::query()
+            ->where('integrity_run_id', $this->run->id)
+            ->where('compared_to_id', $deltaId)
+            ->where('change_type_id', $changeTypeId)
+            ->orderByDesc('severity_id') // critical (highest id) first, never truncated away
+            ->orderBy('path')
+            ->limit($limit)
+            ->pluck('path')
+            ->all();
+    }
+
+    private function discordBlock(string $type): string
+    {
+        $paths = $this->pathsFor($type);
+        if (empty($paths)) {
+            return '—';
+        }
+
+        $text = implode("\n", array_map(fn ($p) => '`' . $p . '`', $paths));
+
+        if (($more = $this->count($type) - count($paths)) > 0) {
+            $text .= "\n+{$more} more";
+        }
+
+        // Discord embed field values hard-cap at 1024 chars.
+        return mb_strlen($text) > 1000 ? mb_substr($text, 0, 990) . "\n…" : $text;
+    }
+
+    private function slackBlock(string $type): string
+    {
+        $paths = $this->pathsFor($type);
+        if (empty($paths)) {
+            return '—';
+        }
+
+        $text = implode("\n", $paths);
+        if (($more = $this->count($type) - count($paths)) > 0) {
+            $text .= "\n+{$more} more";
+        }
+
+        return $text;
+    }
+}

--- a/src/Notifications/Notifiable.php
+++ b/src/Notifications/Notifiable.php
@@ -10,17 +10,17 @@ class Notifiable
 
     public function routeNotificationForMail()
     {
-        return config('shield.notifications.mail.to');
+        return config('shield.notification_channels.mail.to');
     }
 
     public function routeNotificationForSlack()
     {
-        return config('shield.notifications.slack.to');
+        return config('shield.notification_channels.slack.to'); // incoming webhook URL
     }
 
     public function routeNotificationForDiscord()
     {
-        return config('shield.notifications.discord.webhook_url');
+        return config('shield.notification_channels.discord.webhook_url');
     }
 
     public function getKey()

--- a/src/Notifications/SecurityReportNotification.php
+++ b/src/Notifications/SecurityReportNotification.php
@@ -16,54 +16,58 @@ class SecurityReportNotification extends Notification implements ShouldQueue
     use Queueable;
 
     /**
-     * The notification config.
+     * The configured event key this notification is delivered under.
      */
-    public array $notifications = [];
+    protected string $event = 'security_report';
 
     /**
      * Create a notification instance.
-     *
-     * @param  object  $log
      */
     public function __construct(
-        public $recentlyModifiedFiles = [],
+        public array $recentlyModifiedFiles,
         public Carbon $start,
         public Carbon $end,
-    )
-    {
+    ) {
     }
 
     /**
      * Get the notification's channels.
      *
      * @param  mixed  $notifiable
-     * @return array|string
+     * @return array
      */
-    public function via($notifiable)
+    public function via($notifiable): array
     {
         $channels = [];
 
-//        foreach ($this->notifications as $channel => $settings) {
-//            if (empty($settings['enabled'])) {
-//                continue;
-//            }
-//
-//            $channels[] = $this->getChannelClass($channel);
-//        }
-        $channels = ['mail'];
+        foreach (config("shield.notifications.{$this->event}.channels", []) as $channel) {
+            if (! config("shield.notification_channels.{$channel}.enabled")) {
+                continue;
+            }
+
+            $channels[] = $this->getChannelClass($channel);
+        }
 
         return $channels;
     }
 
     /**
-     * Get the notification's queues.
-     * @return array|string
+     * Map each configured channel to the queue it should be sent on.
+     *
+     * Keyed by the same channel identifier `via()` returns (the channel class
+     * for Discord, the channel name otherwise) so Laravel can resolve it.
+     *
+     * @return array
      */
     public function viaQueues(): array
     {
-        return array_map(function ($channel) {
-            return $channel['queue'] ?? 'default';
-        }, $this->notifications);
+        $queues = [];
+
+        foreach (config("shield.notifications.{$this->event}.channels", []) as $channel) {
+            $queues[$this->getChannelClass($channel)] = config("shield.notification_channels.{$channel}.queue", 'default');
+        }
+
+        return $queues;
     }
 
     /**
@@ -75,6 +79,11 @@ class SecurityReportNotification extends Notification implements ShouldQueue
     public function toMail($notifiable)
     {
         $domain = request()->getSchemeAndHttpHost();
+
+        $subject = trans('shield::notifications.security_report.mail.subject', [
+            'domain' => $domain,
+        ]);
+
         $message = trans('shield::notifications.security_report.mail.message', [
             'domain' => "**[$domain]($domain)**",
             'start' => "**{$this->start->format('d/m/Y')}**",
@@ -87,8 +96,8 @@ class SecurityReportNotification extends Notification implements ShouldQueue
                 'message' => $message,
                 'recentlyModifiedFiles' => $this->recentlyModifiedFiles,
             ])
-//            ->from($this->notifications['mail']['from'], $this->notifications['mail']['name'])
-            ->subject($subject ?? 'Security Report')
+            ->from(config('shield.notification_channels.mail.from'), config('shield.notification_channels.mail.name'))
+            ->subject($subject)
             ->action('View Security Dashboard', app('shield')->route('dashboard.index'));
     }
 
@@ -100,52 +109,34 @@ class SecurityReportNotification extends Notification implements ShouldQueue
      */
     public function toSlack($notifiable)
     {
-        $message = trans('shield::notifications.slack.message', [
+        $message = trans('shield::notifications.security_report.slack.message', [
             'domain' => request()->getHttpHost(),
+            'start' => $this->start->format('d/m/Y'),
+            'end' => $this->end->format('d/m/Y'),
         ]);
 
         return (new SlackMessage)
-            ->error()
-            ->from($this->notifications['slack']['from'], $this->notifications['slack']['emoji'])
-            ->to($this->notifications['slack']['channel'])
-            ->content($message)
-            ->attachment(function ($attachment) {
-                $attachment->fields([
-                    'IP' => $this->log->ip,
-                    'Type' => ucfirst($this->log->middleware),
-                    'User ID' => $this->log->user_id,
-                    'URL' => $this->log->url,
-                ]);
-            });
+            ->from(config('shield.notification_channels.slack.from'), config('shield.notification_channels.slack.emoji'))
+            ->to(config('shield.notification_channels.slack.channel'))
+            ->content($message);
     }
 
     public function toDiscord()
     {
-        $body = trans('shield::notifications.discord.message', [
+        $body = trans('shield::notifications.security_report.discord.message', [
             'domain' => request()->getHttpHost(),
+            'start' => $this->start->format('d/m/Y'),
+            'end' => $this->end->format('d/m/Y'),
         ]);
 
         return (new DiscordMessage)
-            ->from('test', 'https://ozankurt.com/images/min/ozan_kurt.png')
-            ->url('https://ozankurt.com/images/min/ozan_kurt.png')
-            ->title('title')
-            ->description('description')
-            ->fields([
-                'label1' => 'test',
-                'label2' => 'test',
-                'label3' => 'test',
-            ], true)
-            ->fields([
-                'label4' => 'test',
-                'label5' => 'test',
-            ], true)
-            ->fields([
-                'label6' => 'test',
-            ], false)
-            ->timestamp(now()->addWeek())
-            ->footer('footer')
-            ->success()
-            ;
+            ->from(config('shield.notification_channels.discord.from'), config('shield.notification_channels.discord.from_img'))
+            ->url(config('shield.notification_channels.discord.route'))
+            ->title(config('shield.notification_channels.discord.title'))
+            ->description($body)
+            ->timestamp(now())
+            ->footer(config('shield.notification_channels.discord.footer'), config('shield.notification_channels.discord.footer_img'))
+            ->success();
     }
 
     public function getChannelClass(string $channel): string

--- a/src/Notifications/SuccessfulLoginNotification.php
+++ b/src/Notifications/SuccessfulLoginNotification.php
@@ -2,110 +2,147 @@
 
 namespace OzanKurt\Shield\Notifications;
 
-use Illuminate\Auth\Events\Authenticated;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
 use OzanKurt\Shield\Models\AuthLog;
+use OzanKurt\Shield\Notifications\Channels\Discord\DiscordChannel;
+use OzanKurt\Shield\Notifications\Channels\Discord\DiscordMessage;
 
 class SuccessfulLoginNotification extends Notification implements ShouldQueue
 {
     use Queueable;
 
-    public array $config;
+    /**
+     * The configured event key this notification is delivered under.
+     */
+    protected string $event = 'successful_login';
 
     public function __construct(
         public AuthLog $authLog
-    )
-    {
-        $this->config = config('shield.notifications.successful_login');
+    ) {
     }
 
     /**
      * Get the notification's channels.
      *
-     * @param mixed $notifiable
+     * @param  mixed  $notifiable
      * @return array
      */
     public function via($notifiable): array
     {
         $channels = [];
 
-        foreach ($this->config['channels'] as $channel => $settings) {
-            if (empty($settings['enabled'])) {
+        foreach (config("shield.notifications.{$this->event}.channels", []) as $channel) {
+            if (! config("shield.notification_channels.{$channel}.enabled")) {
                 continue;
             }
 
-            $channels[] = $channel;
+            $channels[] = $this->getChannelClass($channel);
         }
 
         return $channels;
     }
 
     /**
-     * Get the notification's queues.
+     * Map each configured channel to the queue it should be sent on.
+     *
+     * Keyed by the same channel identifier `via()` returns (the channel class
+     * for Discord, the channel name otherwise) so Laravel can resolve it.
      *
      * @return array
      */
     public function viaQueues(): array
     {
-        return array_map(static function ($channel) {
-            return $channel['queue'] ?? 'default';
-        }, $this->$this->config['channels']);
+        $queues = [];
+
+        foreach (config("shield.notifications.{$this->event}.channels", []) as $channel) {
+            $queues[$this->getChannelClass($channel)] = config("shield.notification_channels.{$channel}.queue", 'default');
+        }
+
+        return $queues;
     }
 
     /**
      * Build the mail representation of the notification.
      *
-     * @param mixed $notifiable
+     * @param  mixed  $notifiable
      * @return \Illuminate\Notifications\Messages\MailMessage
      */
     public function toMail($notifiable)
     {
         $domain = request()->getHttpHost();
 
-        $subject = trans('shield::notifications.mail.subject', [
+        $subject = trans('shield::notifications.successful_login.mail.subject', [
             'domain' => $domain,
         ]);
 
-        $message = trans('shield::notifications.mail.message', [
+        $message = trans('shield::notifications.successful_login.mail.message', [
             'domain' => $domain,
-            'middleware' => ucfirst($this->log->middleware),
-            'ip' => $this->log->ip,
-            'url' => $this->log->url,
         ]);
 
         return (new MailMessage)
-            ->from($this->notifications['mail']['from'], $this->notifications['mail']['name'])
+            ->from(config('shield.notification_channels.mail.from'), config('shield.notification_channels.mail.name'))
             ->subject($subject)
-            ->line($message);
+            ->line($message)
+            ->line('Email: '.$this->authLog->email)
+            ->line('IP: '.$this->authLog->ip);
     }
 
     /**
      * Get the Slack representation of the notification.
      *
-     * @param mixed $notifiable
+     * @param  mixed  $notifiable
      * @return SlackMessage
      */
     public function toSlack($notifiable)
     {
-        $message = trans('shield::notifications.slack.message', [
+        $message = trans('shield::notifications.successful_login.slack.message', [
             'domain' => request()->getHttpHost(),
         ]);
 
         return (new SlackMessage)
-            ->error()
-            ->from($this->notifications['slack']['from'], $this->notifications['slack']['emoji'])
-            ->to($this->notifications['slack']['channel'])
+            ->success()
+            ->from(config('shield.notification_channels.slack.from'), config('shield.notification_channels.slack.emoji'))
+            ->to(config('shield.notification_channels.slack.channel'))
             ->content($message)
             ->attachment(function ($attachment) {
                 $attachment->fields([
-                    'IP' => $this->log->ip,
-                    'Type' => ucfirst($this->log->middleware),
-                    'User ID' => $this->log->user_id,
-                    'URL' => $this->log->url,
+                    'Email' => $this->authLog->email,
+                    'IP' => $this->authLog->ip,
+                    'User ID' => $this->authLog->user_id ?? 'Guest',
                 ]);
             });
+    }
+
+    public function toDiscord()
+    {
+        $body = trans('shield::notifications.successful_login.discord.message', [
+            'domain' => request()->getHttpHost(),
+        ]);
+
+        return (new DiscordMessage)
+            ->from(config('shield.notification_channels.discord.from'), config('shield.notification_channels.discord.from_img'))
+            ->url(config('shield.notification_channels.discord.route'))
+            ->title(config('shield.notification_channels.discord.title'))
+            ->description($body)
+            ->fields([
+                'Email' => $this->authLog->email,
+                'IP' => $this->authLog->ip,
+                'User ID' => $this->authLog->user_id ?? 'Guest',
+            ], true)
+            ->timestamp(now())
+            ->footer(config('shield.notification_channels.discord.footer'), config('shield.notification_channels.discord.footer_img'))
+            ->success();
+    }
+
+    public function getChannelClass(string $channel): string
+    {
+        return match ($channel) {
+            'discord' => DiscordChannel::class,
+            default => $channel,
+        };
     }
 }

--- a/src/Services/Acl/Matchers/HostnameMatcher.php
+++ b/src/Services/Acl/Matchers/HostnameMatcher.php
@@ -7,7 +7,7 @@ use Illuminate\Http\Request;
 class HostnameMatcher implements AclMatcher
 {
     /**
-     * Stub for beta.1 — full implementation lands in a later release.
+     * Stub for beta.1, full implementation lands in a later release.
      * Always returns false so hostname-kinded ACL entries are no-ops until then.
      */
     public function matches(Request $request, string $value): bool

--- a/src/Services/Audit/AuditLogger.php
+++ b/src/Services/Audit/AuditLogger.php
@@ -63,11 +63,11 @@ class AuditLogger
      *   - shield.premium.webhook_ingest_url is configured (non-null), AND
      *   - the site holds an active premium license, AND
      *   - the local Laravel queue connection is set up (no sync queues
-     *     in production, please — we DON'T want each audit row to make
+     *     in production, please, we DON'T want each audit row to make
      *     a synchronous HTTP call to Central).
      *
      * Job is queued on the configured queue with retry/backoff. Failures
-     * are best-effort and never bubble up to break the audit-log write —
+     * are best-effort and never bubble up to break the audit-log write -
      * the local row is the source of truth.
      */
     private function maybeForwardToCentral(AuditLog $entry, string $kindName, string $severity): void
@@ -77,12 +77,12 @@ class AuditLogger
             return;
         }
 
-        // CRITICAL: must NOT call Shield::isPremium() here — that triggers
+        // CRITICAL: must NOT call Shield::isPremium() here, that triggers
         // LicenseChecker::state() which can fire a synchronous 10s HTTP
         // call to Central on cache miss. Every audit_log write would then
         // stall the request thread. Use the cache-only path; the cache is
         // populated by cron-scheduled refreshes + the License dashboard
-        // page. If the cache is cold, we skip forwarding for this write —
+        // page. If the cache is cold, we skip forwarding for this write -
         // the local row is still authoritative.
         try {
             $checker = app(\OzanKurt\Shield\Services\Premium\LicenseChecker::class);
@@ -116,7 +116,7 @@ class AuditLogger
             ForwardAuditToCentralJob::dispatch($payload)
                 ->onQueue((string) config('shield.premium.queue', 'default'));
         } catch (\Throwable $e) {
-            // Queue not configured / table missing — degrade silently.
+            // Queue not configured / table missing, degrade silently.
             // The local row already exists and is the source of truth.
             // Log at info level so operators can find it if they're
             // wondering why nothing reaches Central.

--- a/src/Services/Audit/EnvAuditor.php
+++ b/src/Services/Audit/EnvAuditor.php
@@ -45,7 +45,7 @@ class EnvAuditor
         }
 
         if (! config('app.url') || config('app.url') === 'http://localhost') {
-            $findings[] = ['key' => 'APP_URL', 'severity' => 'low', 'message' => 'APP_URL is set to the default — set to your real domain for correct URL generation.'];
+            $findings[] = ['key' => 'APP_URL', 'severity' => 'low', 'message' => 'APP_URL is set to the default, set to your real domain for correct URL generation.'];
         }
 
         return $findings;

--- a/src/Services/Integrity/Baseline.php
+++ b/src/Services/Integrity/Baseline.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace OzanKurt\Shield\Services\Integrity;
+
+use InvalidArgumentException;
+
+/**
+ * Reads and writes the pinned known-good baseline as a signed, atomically
+ * written, gzipped NDJSON artifact.
+ *
+ * Artifact layout (before gzip): one header line then one line per file entry.
+ * A sidecar `.sig` file holds the HMAC over the uncompressed NDJSON, with a
+ * domain-separation prefix so a signature cannot be reused in another context.
+ *
+ * Honest threat model (see spec-005 section 4.2): a same-host attacker with the
+ * key can re-sign, so the HMAC defends against unprivileged storage writes and
+ * accidental corruption, not a full host compromise. Real attestation is Phase 3.
+ */
+class Baseline
+{
+    public const DOMAIN = 'shield.integrity.baseline.v1';
+
+    /** A resolved key equal to this placeholder is rejected (fail closed). */
+    public const PLACEHOLDER_KEY = 'please-set-LS_INTEGRITY_HMAC_KEY';
+
+    public function __construct(
+        private string $key,
+        private string $algo = 'sha256'
+    ) {
+        self::assertUsableKey($key);
+    }
+
+    /**
+     * Refuse to operate with an empty or placeholder signing key.
+     *
+     * @throws InvalidArgumentException
+     */
+    public static function assertUsableKey(string $key): void
+    {
+        if ($key === '' || $key === self::PLACEHOLDER_KEY) {
+            throw new InvalidArgumentException(
+                'Integrity baseline signing key is unset or still the placeholder. '
+                . 'Set LS_INTEGRITY_HMAC_KEY (or integrity.baseline.hmac_key_path) to a real secret outside the scan root.'
+            );
+        }
+    }
+
+    /**
+     * Atomically write a signed baseline artifact.
+     *
+     * @param  array<string,array>  $manifest
+     * @param  array<string,mixed>  $meta
+     */
+    public function write(string $path, array $manifest, array $meta): void
+    {
+        $ndjson = $this->encode($manifest, $meta);
+        $signature = $this->sign($ndjson);
+
+        $dir = dirname($path);
+        if (! is_dir($dir)) {
+            @mkdir($dir, 0775, true);
+        }
+
+        $tmp = $path . '.tmp';
+        file_put_contents($tmp, gzencode($ndjson, 6));
+        file_put_contents($path . '.sig.tmp', $signature);
+
+        // Rename is atomic on the same filesystem; the .sig flips first so a
+        // reader never sees a new artifact paired with a stale signature.
+        rename($path . '.sig.tmp', $path . '.sig');
+        rename($tmp, $path);
+    }
+
+    /**
+     * Read and verify a baseline artifact.
+     *
+     * @return array{manifest: array<string,array>, meta: array<string,mixed>}|null
+     *                                          null when no artifact exists (first-run path)
+     *
+     * @throws BaselineCorruptException
+     * @throws BaselineTamperException
+     */
+    public function read(string $path): ?array
+    {
+        if (! is_file($path)) {
+            return null;
+        }
+
+        $gz = @file_get_contents($path);
+        $ndjson = $gz === false ? false : @gzdecode($gz);
+        if ($ndjson === false) {
+            throw new BaselineCorruptException("Baseline artifact at {$path} could not be decompressed.");
+        }
+
+        if (! is_file($path . '.sig')) {
+            throw new BaselineCorruptException("Baseline signature for {$path} is missing.");
+        }
+
+        $expected = (string) @file_get_contents($path . '.sig');
+        if (! hash_equals($this->sign($ndjson), $expected)) {
+            throw new BaselineTamperException("Baseline signature for {$path} does not verify.");
+        }
+
+        return $this->decode($ndjson, $path);
+    }
+
+    private function sign(string $ndjson): string
+    {
+        return hash_hmac($this->algo, self::DOMAIN . "\n" . $ndjson, $this->key);
+    }
+
+    /**
+     * @param  array<string,array>  $manifest
+     * @param  array<string,mixed>  $meta
+     */
+    private function encode(array $manifest, array $meta): string
+    {
+        ksort($manifest);
+
+        $lines = [json_encode(['_meta' => $meta], JSON_UNESCAPED_SLASHES)];
+        foreach ($manifest as $key => $e) {
+            $lines[] = json_encode([
+                'p' => $key,
+                'h' => $e['sha256'] ?? null,
+                's' => $e['size'] ?? 0,
+                'm' => $e['mtime'] ?? 0,
+                'k' => $e['kind'] ?? 'hashed',
+                't' => $e['target'] ?? null,
+            ], JSON_UNESCAPED_SLASHES);
+        }
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * @return array{manifest: array<string,array>, meta: array<string,mixed>}
+     *
+     * @throws BaselineCorruptException
+     */
+    private function decode(string $ndjson, string $path): array
+    {
+        $lines = explode("\n", trim($ndjson, "\n"));
+        $header = json_decode(array_shift($lines) ?: '', true);
+        if (! is_array($header) || ! array_key_exists('_meta', $header)) {
+            throw new BaselineCorruptException("Baseline artifact at {$path} has an invalid header.");
+        }
+
+        $manifest = [];
+        foreach ($lines as $line) {
+            if ($line === '') {
+                continue;
+            }
+            $row = json_decode($line, true);
+            if (! is_array($row) || ! isset($row['p'])) {
+                throw new BaselineCorruptException("Baseline artifact at {$path} has a malformed entry.");
+            }
+            $manifest[$row['p']] = [
+                'sha256' => $row['h'] ?? null,
+                'size' => (int) ($row['s'] ?? 0),
+                'mtime' => (int) ($row['m'] ?? 0),
+                'kind' => $row['k'] ?? 'hashed',
+                'target' => $row['t'] ?? null,
+            ];
+        }
+
+        return ['manifest' => $manifest, 'meta' => $header['_meta']];
+    }
+}

--- a/src/Services/Integrity/Baseline.php
+++ b/src/Services/Integrity/Baseline.php
@@ -3,6 +3,7 @@
 namespace OzanKurt\Shield\Services\Integrity;
 
 use InvalidArgumentException;
+use RuntimeException;
 
 /**
  * Reads and writes the pinned known-good baseline as a signed, atomically
@@ -57,18 +58,21 @@ class Baseline
         $signature = $this->sign($ndjson);
 
         $dir = dirname($path);
-        if (! is_dir($dir)) {
-            @mkdir($dir, 0775, true);
+        if (! is_dir($dir) && ! @mkdir($dir, 0775, true) && ! is_dir($dir)) {
+            throw new RuntimeException("Could not create baseline directory {$dir} (not writable?).");
         }
 
         $tmp = $path . '.tmp';
-        file_put_contents($tmp, gzencode($ndjson, 6));
-        file_put_contents($path . '.sig.tmp', $signature);
+        if (@file_put_contents($tmp, gzencode($ndjson, 6)) === false
+            || @file_put_contents($path . '.sig.tmp', $signature) === false) {
+            throw new RuntimeException("Could not write baseline artifact under {$dir} (not writable?).");
+        }
 
         // Rename is atomic on the same filesystem; the .sig flips first so a
         // reader never sees a new artifact paired with a stale signature.
-        rename($path . '.sig.tmp', $path . '.sig');
-        rename($tmp, $path);
+        if (! @rename($path . '.sig.tmp', $path . '.sig') || ! @rename($tmp, $path)) {
+            throw new RuntimeException("Could not finalize baseline artifact at {$path}.");
+        }
     }
 
     /**

--- a/src/Services/Integrity/BaselineCorruptException.php
+++ b/src/Services/Integrity/BaselineCorruptException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OzanKurt\Shield\Services\Integrity;
+
+use RuntimeException;
+
+/**
+ * Thrown when a baseline artifact exists but cannot be decompressed or parsed
+ * (e.g. a partial write from a crashed bless). Benign, but the scanner should
+ * fail the run and require an explicit re-bless rather than silently rebuilding.
+ */
+class BaselineCorruptException extends RuntimeException
+{
+}

--- a/src/Services/Integrity/BaselineTamperException.php
+++ b/src/Services/Integrity/BaselineTamperException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OzanKurt\Shield\Services\Integrity;
+
+use RuntimeException;
+
+/**
+ * Thrown when a baseline artifact exists and parses but its HMAC signature does
+ * not verify. This is a SECURITY signal (someone rewrote the approved baseline),
+ * distinct from benign corruption. The scanner must NOT auto-rebless on this.
+ */
+class BaselineTamperException extends RuntimeException
+{
+}

--- a/src/Services/Integrity/IntegrityScanner.php
+++ b/src/Services/Integrity/IntegrityScanner.php
@@ -1,0 +1,383 @@
+<?php
+
+namespace OzanKurt\Shield\Services\Integrity;
+
+use Illuminate\Support\Facades\Cache;
+use InvalidArgumentException;
+use OzanKurt\Shield\Events\IntegrityScanCompletedEvent;
+use OzanKurt\Shield\Models\IntegrityBaseline;
+use OzanKurt\Shield\Models\IntegrityChange;
+use OzanKurt\Shield\Models\IntegrityRun;
+use OzanKurt\Shield\Models\Lookups\IntegrityChangeType;
+use OzanKurt\Shield\Models\Lookups\IntegrityComparisonBasis;
+use OzanKurt\Shield\Models\Lookups\IntegrityStatus;
+use OzanKurt\Shield\Models\Lookups\LogLevel;
+use OzanKurt\Shield\Models\Lookups\ScannerTrigger;
+use Throwable;
+
+/**
+ * Orchestrates one file-integrity scan: lock, load + verify the known-good
+ * baseline, build the current manifest, diff vs known-good and vs the previous
+ * run (hybrid), classify + score changes, persist the run + change rows, and
+ * fire IntegrityScanCompletedEvent.
+ *
+ * Secure by default: a missing baseline establishes a PROVISIONAL one (never
+ * silently trusted); a tampered baseline is a security signal that does NOT
+ * auto-rebless.
+ */
+class IntegrityScanner
+{
+    private const SEVERITY_ORDER = ['low' => 1, 'medium' => 2, 'high' => 3, 'critical' => 4];
+
+    public function run(string $diskName = 'app', string $triggerName = 'manual'): IntegrityRun
+    {
+        $spec = config("shield.integrity.disks.{$diskName}");
+        if (! is_array($spec)) {
+            throw new InvalidArgumentException("Unknown integrity disk [{$diskName}].");
+        }
+
+        $maxRuntime = (int) config('shield.integrity.limits.max_runtime', 3600);
+        $lock = Cache::lock("shield:integrity:{$diskName}", $maxRuntime);
+
+        if (! $lock->get()) {
+            return $this->persistRun($diskName, $triggerName, 'skipped');
+        }
+
+        try {
+            return $this->execute($diskName, $triggerName, $spec);
+        } finally {
+            $lock->release();
+        }
+    }
+
+    private function execute(string $diskName, string $triggerName, array $spec): IntegrityRun
+    {
+        $algo = (string) config('shield.integrity.hash_algo', 'sha256');
+        $keyBase = $spec['key_base'] ?? base_path();
+
+        $manifestSpec = [
+            'roots' => $this->resolveRoots($spec),
+            'key_base' => $keyBase,
+            'include' => $spec['include'] ?? ['**/*'],
+            'exclude' => $spec['exclude'] ?? [],
+            'follow_symlinks' => $spec['follow_symlinks'] ?? false,
+            'max_file_size' => $spec['max_file_size'] ?? 50 * 1024 * 1024,
+            'hash_algo' => $algo,
+            'max_files' => (int) config('shield.integrity.limits.max_files', 500000),
+            'max_iterations' => (int) config('shield.integrity.limits.max_iterations', 1000000),
+        ];
+
+        $scopeFingerprint = hash('sha256', json_encode([
+            'include' => $manifestSpec['include'],
+            'exclude' => $manifestSpec['exclude'],
+            'follow_symlinks' => $manifestSpec['follow_symlinks'],
+            'max_file_size' => $manifestSpec['max_file_size'],
+            'algo' => $algo,
+            'disk' => $diskName,
+        ]));
+
+        $baseline = new Baseline($this->resolveKey(), $algo);
+        $knownGoodPath = $this->artifactPath($diskName, 'baseline');
+        $lastRunPath = $this->artifactPath($diskName, 'last-run');
+
+        // Load + verify the known-good baseline. Tamper and corruption are
+        // distinct, and neither auto-rebuilds the baseline.
+        try {
+            $knownGood = $baseline->read($knownGoodPath);
+        } catch (BaselineTamperException $e) {
+            return $this->persistRun($diskName, $triggerName, 'tamper_suspected', 'critical', $e->getMessage());
+        } catch (BaselineCorruptException $e) {
+            return $this->persistRun($diskName, $triggerName, 'failed', null, $e->getMessage());
+        }
+
+        $startedAt = now();
+
+        try {
+            $current = (new Manifest($manifestSpec))->build($knownGood['manifest'] ?? []);
+        } catch (ManifestLimitException $e) {
+            return $this->persistRun($diskName, $triggerName, 'aborted_limit', 'high', $e->getMessage(), $startedAt);
+        }
+
+        $counters = $this->countKinds($current);
+        $rootHash = Manifest::rootHash($current, $algo);
+
+        // First run: establish a PROVISIONAL baseline, do not trust it.
+        if ($knownGood === null) {
+            $meta = ['disk' => $diskName, 'scope_fingerprint' => $scopeFingerprint, 'root_hash' => $rootHash, 'files_total' => count($current)];
+            $baseline->write($knownGoodPath, $current, $meta);
+            $baseline->write($lastRunPath, $current, $meta);
+            $this->upsertBaselineRow($diskName, $scopeFingerprint, $rootHash, $knownGoodPath, $algo, count($current), false);
+
+            $run = $this->persistRun($diskName, $triggerName, 'baseline_established', null, null, $startedAt, [
+                'scope_fingerprint' => $scopeFingerprint,
+                'current_root_hash' => $rootHash,
+            ] + $counters);
+
+            IntegrityScanCompletedEvent::dispatch($run);
+
+            return $run;
+        }
+
+        // Hybrid diff: delta vs the previous run, drift vs known-good.
+        $scopeChanged = ($knownGood['meta']['scope_fingerprint'] ?? null) !== $scopeFingerprint;
+
+        $lastRun = null;
+        try {
+            $lastRun = $baseline->read($lastRunPath);
+        } catch (Throwable) {
+            $lastRun = null;
+        }
+
+        $delta = Manifest::diff($lastRun['manifest'] ?? $knownGood['manifest'], $current);
+        $drift = Manifest::diff($knownGood['manifest'], $current);
+
+        $run = $this->persistRun($diskName, $triggerName, 'running', null, null, $startedAt, [
+            'scope_fingerprint' => $scopeFingerprint,
+            'baseline_root_hash' => $knownGood['meta']['root_hash'] ?? null,
+            'current_root_hash' => $rootHash,
+        ] + $counters);
+
+        $evaluator = new SeverityRuleEvaluator(
+            config('shield.integrity.severity_rules', []),
+            ['public_docroot' => $this->publicDocroot($keyBase)]
+        );
+        $maps = $this->lookupMaps();
+        $maxChanges = (int) config('shield.integrity.limits.max_persisted_changes_per_run', 5000);
+
+        $persisted = 0;
+        $maxSeverity = 'low';
+
+        foreach (['last_run' => $delta, 'known_good' => $drift] as $basis => $diff) {
+            foreach (['new', 'modified', 'deleted'] as $bucket) {
+                foreach ($diff[$bucket] as $path => $entry) {
+                    if ($persisted >= $maxChanges) {
+                        break 3;
+                    }
+
+                    $changeType = $this->classify($bucket, $entry, $scopeChanged);
+                    $severity = $evaluator->evaluate($path, $changeType);
+                    $maxSeverity = $this->maxSeverity($maxSeverity, $severity);
+
+                    IntegrityChange::create([
+                        'integrity_run_id' => $run->id,
+                        'change_type_id' => $maps['change_type'][$changeType] ?? $maps['change_type']['modified'],
+                        'compared_to_id' => $maps['comparison'][$basis],
+                        'severity_id' => $maps['severity'][$severity] ?? null,
+                        'path' => mb_substr($path, 0, 1024),
+                        'old_hash' => $bucket === 'deleted' ? ($entry['sha256'] ?? null) : null,
+                        'new_hash' => $bucket === 'deleted' ? null : ($entry['sha256'] ?? null),
+                        'size_bytes' => $entry['size'] ?? null,
+                        'symlink_target' => $entry['target'] ?? null,
+                    ]);
+
+                    $persisted++;
+                }
+            }
+        }
+
+        $driftTotal = count($drift['new']) + count($drift['modified']) + count($drift['deleted']);
+
+        $run->update([
+            'status_id' => $this->statusId('completed'),
+            'severity_id' => $maps['severity'][$maxSeverity] ?? null,
+            'count_new' => count($delta['new']),
+            'count_modified' => count($delta['modified']),
+            'count_deleted' => count($delta['deleted']),
+            'count_scope_changed' => $scopeChanged ? ($driftTotal) : 0,
+            'count_vs_known_good' => $driftTotal,
+            'finished_at' => now(),
+            'duration_ms' => (int) (now()->diffInMilliseconds($startedAt)),
+        ]);
+
+        // The current state becomes the previous-run reference for next time.
+        $baseline->write($lastRunPath, $current, [
+            'disk' => $diskName, 'scope_fingerprint' => $scopeFingerprint, 'root_hash' => $rootHash, 'files_total' => count($current),
+        ]);
+
+        $run = $run->fresh();
+        IntegrityScanCompletedEvent::dispatch($run);
+
+        return $run;
+    }
+
+    /**
+     * Promote the most recent run's state to the known-good baseline.
+     */
+    public function bless(string $diskName = 'app'): IntegrityBaseline
+    {
+        $spec = config("shield.integrity.disks.{$diskName}");
+        if (! is_array($spec)) {
+            throw new InvalidArgumentException("Unknown integrity disk [{$diskName}].");
+        }
+
+        $algo = (string) config('shield.integrity.hash_algo', 'sha256');
+        $baseline = new Baseline($this->resolveKey(), $algo);
+        $lastRunPath = $this->artifactPath($diskName, 'last-run');
+        $knownGoodPath = $this->artifactPath($diskName, 'baseline');
+
+        $lastRun = $baseline->read($lastRunPath);
+        if ($lastRun === null) {
+            throw new InvalidArgumentException("No prior run to bless for disk [{$diskName}]. Run shield:integrity first.");
+        }
+
+        $rootHash = Manifest::rootHash($lastRun['manifest'], $algo);
+        $meta = $lastRun['meta'];
+        $meta['root_hash'] = $rootHash;
+        $baseline->write($knownGoodPath, $lastRun['manifest'], $meta);
+
+        return $this->upsertBaselineRow(
+            $diskName,
+            $meta['scope_fingerprint'] ?? null,
+            $rootHash,
+            $knownGoodPath,
+            $algo,
+            count($lastRun['manifest']),
+            true
+        );
+    }
+
+    private function classify(string $bucket, array $entry, bool $scopeChanged): string
+    {
+        if ($scopeChanged && in_array($bucket, ['new', 'deleted'], true)) {
+            return 'scope_changed';
+        }
+
+        if ($bucket === 'new' && ($entry['kind'] ?? null) === 'symlink') {
+            return 'symlink_new';
+        }
+
+        if ($bucket === 'modified' && ($entry['kind'] ?? null) === 'unreadable') {
+            return 'became_unreadable';
+        }
+
+        return $bucket; // new | modified | deleted
+    }
+
+    private function maxSeverity(string $a, string $b): string
+    {
+        return (self::SEVERITY_ORDER[$b] ?? 1) > (self::SEVERITY_ORDER[$a] ?? 1) ? $b : $a;
+    }
+
+    /** @return array{files_total:int,files_hashed:int,files_size_only:int,files_unreadable:int,files_excluded:int} */
+    private function countKinds(array $manifest): array
+    {
+        $hashed = $sizeOnly = $unreadable = 0;
+        foreach ($manifest as $e) {
+            match ($e['kind'] ?? 'hashed') {
+                'size_only' => $sizeOnly++,
+                'unreadable' => $unreadable++,
+                default => $hashed++,
+            };
+        }
+
+        return [
+            'files_total' => count($manifest),
+            'files_hashed' => $hashed,
+            'files_size_only' => $sizeOnly,
+            'files_unreadable' => $unreadable,
+            'files_excluded' => 0,
+        ];
+    }
+
+    /** @return string[] absolute roots */
+    private function resolveRoots(array $spec): array
+    {
+        $roots = (array) ($spec['roots'] ?? [base_path()]);
+        $resolved = [];
+        foreach ($roots as $root) {
+            $resolved[] = preg_match('#^([a-zA-Z]:[\\\\/]|/)#', $root) ? $root : base_path($root);
+        }
+
+        return $resolved;
+    }
+
+    private function publicDocroot(string $keyBase): string
+    {
+        $public = str_replace('\\', '/', public_path());
+        $base = rtrim(str_replace('\\', '/', $keyBase), '/');
+        if (str_starts_with($public, $base . '/')) {
+            return substr($public, strlen($base) + 1);
+        }
+
+        return 'public';
+    }
+
+    private function resolveKey(): string
+    {
+        $path = config('shield.integrity.baseline.hmac_key_path');
+        if (is_string($path) && $path !== '' && is_readable($path)) {
+            return trim((string) file_get_contents($path));
+        }
+
+        return (string) config('shield.integrity.baseline.hmac_key', '');
+    }
+
+    private function artifactPath(string $diskName, string $name): string
+    {
+        return storage_path("shield/integrity/{$diskName}/{$name}.ndjson.gz");
+    }
+
+    /**
+     * Persist a run row. Used both for the happy path and for terminal states
+     * (skipped / tamper_suspected / failed / aborted_limit) that exit early.
+     *
+     * @param  array<string,mixed>  $extra
+     */
+    private function persistRun(
+        string $diskName,
+        string $triggerName,
+        string $statusName,
+        ?string $severityName = null,
+        ?string $errorMessage = null,
+        $startedAt = null,
+        array $extra = []
+    ): IntegrityRun {
+        return IntegrityRun::create(array_merge([
+            'status_id' => $this->statusId($statusName),
+            'trigger_id' => ScannerTrigger::where('name', $triggerName)->value('id') ?? ScannerTrigger::where('name', 'manual')->value('id'),
+            'severity_id' => $severityName ? LogLevel::where('name', $severityName)->value('id') : null,
+            'disk' => $diskName,
+            'started_at' => $startedAt ?? now(),
+            'finished_at' => now(),
+            'error_message' => $errorMessage,
+        ], $extra));
+    }
+
+    private function upsertBaselineRow(
+        string $diskName,
+        ?string $scopeFingerprint,
+        string $rootHash,
+        string $artifactPath,
+        string $algo,
+        int $filesTotal,
+        bool $signed
+    ): IntegrityBaseline {
+        IntegrityBaseline::where('disk', $diskName)->delete();
+
+        return IntegrityBaseline::create([
+            'disk' => $diskName,
+            'scope_fingerprint' => $scopeFingerprint,
+            'root_hash' => $rootHash,
+            'artifact_path' => $artifactPath,
+            'algo' => $algo,
+            'files_total' => $filesTotal,
+            'signed' => $signed,
+            'blessed_at' => now(),
+        ]);
+    }
+
+    private function statusId(string $name): int
+    {
+        return (int) IntegrityStatus::where('name', $name)->value('id');
+    }
+
+    /** @return array{change_type:array<string,int>,comparison:array<string,int>,severity:array<string,int>} */
+    private function lookupMaps(): array
+    {
+        return [
+            'change_type' => IntegrityChangeType::pluck('id', 'name')->all(),
+            'comparison' => IntegrityComparisonBasis::pluck('id', 'name')->all(),
+            'severity' => LogLevel::pluck('id', 'name')->all(),
+        ];
+    }
+}

--- a/src/Services/Integrity/IntegrityScanner.php
+++ b/src/Services/Integrity/IntegrityScanner.php
@@ -2,6 +2,7 @@
 
 namespace OzanKurt\Shield\Services\Integrity;
 
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use InvalidArgumentException;
 use OzanKurt\Shield\Events\IntegrityScanCompletedEvent;
@@ -137,62 +138,82 @@ class IntegrityScanner
             'current_root_hash' => $rootHash,
         ] + $counters);
 
-        $evaluator = new SeverityRuleEvaluator(
-            config('shield.integrity.severity_rules', []),
-            ['public_docroot' => $this->publicDocroot($keyBase)]
-        );
-        $maps = $this->lookupMaps();
-        $maxChanges = (int) config('shield.integrity.limits.max_persisted_changes_per_run', 5000);
+        try {
+            $evaluator = new SeverityRuleEvaluator(
+                config('shield.integrity.severity_rules', []),
+                ['public_docroot' => $this->publicDocroot($keyBase)]
+            );
+            $maps = $this->lookupMaps();
+            $maxChanges = (int) config('shield.integrity.limits.max_persisted_changes_per_run', 5000);
 
-        $persisted = 0;
-        $maxSeverity = 'low';
+            // When there is no previous run, the delta was computed against the
+            // known-good manifest, so it is identical to the drift. Persist it once
+            // (as last_run) to avoid duplicate rows.
+            $bases = ['last_run' => $delta];
+            if ($lastRun !== null) {
+                $bases['known_good'] = $drift;
+            }
 
-        foreach (['last_run' => $delta, 'known_good' => $drift] as $basis => $diff) {
-            foreach (['new', 'modified', 'deleted'] as $bucket) {
-                foreach ($diff[$bucket] as $path => $entry) {
-                    if ($persisted >= $maxChanges) {
-                        break 3;
+            $persisted = 0;
+            $maxSeverity = 'low';
+
+            foreach ($bases as $basis => $diff) {
+                foreach (['new', 'modified', 'deleted'] as $bucket) {
+                    foreach ($diff[$bucket] as $path => $entry) {
+                        if ($persisted >= $maxChanges) {
+                            break 3;
+                        }
+
+                        $changeType = $this->classify($bucket, $entry, $scopeChanged);
+                        $severity = $evaluator->evaluate($path, $changeType);
+                        $maxSeverity = $this->maxSeverity($maxSeverity, $severity);
+
+                        IntegrityChange::create([
+                            'integrity_run_id' => $run->id,
+                            'change_type_id' => $maps['change_type'][$changeType] ?? $maps['change_type']['modified'],
+                            'compared_to_id' => $maps['comparison'][$basis],
+                            'severity_id' => $maps['severity'][$severity] ?? null,
+                            'path' => mb_substr($path, 0, 1024),
+                            'old_hash' => $bucket === 'deleted' ? ($entry['sha256'] ?? null) : null,
+                            'new_hash' => $bucket === 'deleted' ? null : ($entry['sha256'] ?? null),
+                            'size_bytes' => $entry['size'] ?? null,
+                            'file_mtime' => empty($entry['mtime']) ? null : Carbon::createFromTimestamp($entry['mtime']),
+                            'symlink_target' => $entry['target'] ?? null,
+                        ]);
+
+                        $persisted++;
                     }
-
-                    $changeType = $this->classify($bucket, $entry, $scopeChanged);
-                    $severity = $evaluator->evaluate($path, $changeType);
-                    $maxSeverity = $this->maxSeverity($maxSeverity, $severity);
-
-                    IntegrityChange::create([
-                        'integrity_run_id' => $run->id,
-                        'change_type_id' => $maps['change_type'][$changeType] ?? $maps['change_type']['modified'],
-                        'compared_to_id' => $maps['comparison'][$basis],
-                        'severity_id' => $maps['severity'][$severity] ?? null,
-                        'path' => mb_substr($path, 0, 1024),
-                        'old_hash' => $bucket === 'deleted' ? ($entry['sha256'] ?? null) : null,
-                        'new_hash' => $bucket === 'deleted' ? null : ($entry['sha256'] ?? null),
-                        'size_bytes' => $entry['size'] ?? null,
-                        'symlink_target' => $entry['target'] ?? null,
-                    ]);
-
-                    $persisted++;
                 }
             }
+
+            $driftTotal = count($drift['new']) + count($drift['modified']) + count($drift['deleted']);
+
+            $run->update([
+                'status_id' => $this->statusId('completed'),
+                'severity_id' => $maps['severity'][$maxSeverity] ?? null,
+                'count_new' => count($delta['new']),
+                'count_modified' => count($delta['modified']),
+                'count_deleted' => count($delta['deleted']),
+                'count_scope_changed' => $scopeChanged ? $driftTotal : 0,
+                'count_vs_known_good' => $driftTotal,
+                'finished_at' => now(),
+                'duration_ms' => (int) now()->diffInMilliseconds($startedAt),
+            ]);
+
+            // The current state becomes the previous-run reference for next time.
+            $baseline->write($lastRunPath, $current, [
+                'disk' => $diskName, 'scope_fingerprint' => $scopeFingerprint, 'root_hash' => $rootHash, 'files_total' => count($current),
+            ]);
+        } catch (Throwable $e) {
+            // Never leave the run stuck in 'running'.
+            $run->update([
+                'status_id' => $this->statusId('failed'),
+                'finished_at' => now(),
+                'error_message' => $e->getMessage(),
+            ]);
+
+            throw $e;
         }
-
-        $driftTotal = count($drift['new']) + count($drift['modified']) + count($drift['deleted']);
-
-        $run->update([
-            'status_id' => $this->statusId('completed'),
-            'severity_id' => $maps['severity'][$maxSeverity] ?? null,
-            'count_new' => count($delta['new']),
-            'count_modified' => count($delta['modified']),
-            'count_deleted' => count($delta['deleted']),
-            'count_scope_changed' => $scopeChanged ? ($driftTotal) : 0,
-            'count_vs_known_good' => $driftTotal,
-            'finished_at' => now(),
-            'duration_ms' => (int) (now()->diffInMilliseconds($startedAt)),
-        ]);
-
-        // The current state becomes the previous-run reference for next time.
-        $baseline->write($lastRunPath, $current, [
-            'disk' => $diskName, 'scope_fingerprint' => $scopeFingerprint, 'root_hash' => $rootHash, 'files_total' => count($current),
-        ]);
 
         $run = $run->fresh();
         IntegrityScanCompletedEvent::dispatch($run);

--- a/src/Services/Integrity/Manifest.php
+++ b/src/Services/Integrity/Manifest.php
@@ -1,0 +1,350 @@
+<?php
+
+namespace OzanKurt\Shield\Services\Integrity;
+
+/**
+ * Builds and diffs file-integrity manifests for a local filesystem scope.
+ *
+ * A manifest maps a canonical disk-relative POSIX path to an entry:
+ *   ['sha256' => ?string, 'size' => int, 'mtime' => int, 'kind' => string, 'target' => ?string]
+ *
+ * kind is one of: hashed | size_only | symlink | unreadable.
+ *
+ * Phase 1 targets the local filesystem (hash_file already streams, so memory
+ * stays flat). Remote disks (sftp/s3) with readStream hashing are Phase 2.
+ *
+ * Pure and DB-free so it can be unit tested in isolation. It is also the shared
+ * hasher the integrity engine uses.
+ */
+class Manifest
+{
+    /** @var string[] absolute roots to walk */
+    private array $roots;
+    private string $keyBase;
+    /** @var string[] */
+    private array $include;
+    /** @var string[] */
+    private array $exclude;
+    private bool $followSymlinks;
+    private int $maxFileSize;
+    private string $algo;
+    /** @var string[] lowercase extensions always hashed regardless of size */
+    private array $alwaysHashExtensions;
+    private int $maxFiles;
+    private int $maxIterations;
+
+    private int $fileCount = 0;
+    private int $iterations = 0;
+    /** @var array<string,bool> realpath dedup for symlink-loop protection */
+    private array $seenDirs = [];
+
+    public function __construct(array $spec)
+    {
+        $this->roots = array_map([$this, 'normalize'], (array) ($spec['roots'] ?? []));
+        $this->keyBase = $this->normalize($spec['key_base'] ?? (defined('ABSPATH') ? ABSPATH : ''));
+        $this->include = (array) ($spec['include'] ?? ['**/*']);
+        $this->exclude = (array) ($spec['exclude'] ?? []);
+        $this->followSymlinks = (bool) ($spec['follow_symlinks'] ?? false);
+        $this->maxFileSize = (int) ($spec['max_file_size'] ?? 50 * 1024 * 1024);
+        $this->algo = (string) ($spec['hash_algo'] ?? 'sha256');
+        $this->alwaysHashExtensions = array_map('strtolower', (array) ($spec['always_hash_extensions'] ?? [
+            'php', 'phtml', 'phar', 'phps', 'inc', 'pht',
+        ]));
+        $this->maxFiles = (int) ($spec['max_files'] ?? 500000);
+        $this->maxIterations = (int) ($spec['max_iterations'] ?? 1000000);
+    }
+
+    /**
+     * Build the manifest. When $previous is supplied, files whose size and mtime
+     * are unchanged carry their prior hash forward instead of being re-hashed
+     * (incremental rescan, the key scale win at large file counts).
+     *
+     * @param  array<string,array>  $previous
+     * @return array<string,array> sorted by path
+     *
+     * @throws ManifestLimitException
+     */
+    public function build(array $previous = []): array
+    {
+        $this->fileCount = 0;
+        $this->iterations = 0;
+        $this->seenDirs = [];
+
+        $manifest = [];
+
+        foreach ($this->roots as $root) {
+            if (is_file($root)) {
+                $this->record($manifest, $root, $previous);
+            } elseif (is_dir($root)) {
+                $this->scanDir($manifest, $root, $previous);
+            }
+        }
+
+        ksort($manifest);
+
+        return $manifest;
+    }
+
+    private function scanDir(array &$manifest, string $dir, array $previous): void
+    {
+        $real = realpath($dir);
+        if ($real !== false) {
+            if (isset($this->seenDirs[$real])) {
+                return; // recursive symlink guard
+            }
+            $this->seenDirs[$real] = true;
+        }
+
+        $handle = @opendir($dir);
+        if ($handle === false) {
+            return;
+        }
+
+        while (($entry = readdir($handle)) !== false) {
+            if ($entry === '.' || $entry === '..') {
+                continue;
+            }
+
+            $path = $this->normalize($dir . '/' . $entry);
+
+            if (++$this->iterations >= $this->maxIterations) {
+                closedir($handle);
+                throw new ManifestLimitException("Manifest exceeded max_iterations ({$this->maxIterations}).");
+            }
+
+            $key = $this->key($path);
+
+            if (is_link($path)) {
+                if ($this->excluded($key)) {
+                    continue;
+                }
+                if (! $this->followSymlinks) {
+                    if ($this->included($key)) {
+                        $lst = @lstat($path);
+                        $this->add($manifest, $key, [
+                            'sha256' => null,
+                            'size' => 0,
+                            'mtime' => is_array($lst) ? (int) $lst['mtime'] : 0,
+                            'kind' => 'symlink',
+                            'target' => @readlink($path) ?: null,
+                        ]);
+                    }
+                    continue;
+                }
+            }
+
+            if (is_dir($path)) {
+                $this->scanDir($manifest, $path, $previous);
+                continue;
+            }
+
+            if (is_file($path)) {
+                $this->record($manifest, $path, $previous);
+            }
+        }
+
+        closedir($handle);
+    }
+
+    private function record(array &$manifest, string $path, array $previous): void
+    {
+        $key = $this->key($path);
+
+        if (! $this->included($key) || $this->excluded($key)) {
+            return;
+        }
+
+        $stat = @stat($path);
+        if ($stat === false) {
+            $this->add($manifest, $key, ['sha256' => null, 'size' => 0, 'mtime' => 0, 'kind' => 'unreadable', 'target' => null]);
+            return;
+        }
+
+        $size = (int) $stat['size'];
+        $mtime = (int) $stat['mtime'];
+
+        // Incremental: carry the prior hash when size+mtime are unchanged.
+        $prior = $previous[$key] ?? null;
+        if ($prior !== null && ($prior['kind'] ?? null) === 'hashed'
+            && (int) ($prior['size'] ?? -1) === $size
+            && (int) ($prior['mtime'] ?? -1) === $mtime
+            && ! empty($prior['sha256'])) {
+            $this->add($manifest, $key, ['sha256' => $prior['sha256'], 'size' => $size, 'mtime' => $mtime, 'kind' => 'hashed', 'target' => null]);
+            return;
+        }
+
+        // Oversized files are recorded by size+mtime only, EXCEPT script
+        // extensions which are always hashed (anti size/mtime-backdating evasion).
+        if ($size > $this->maxFileSize && ! $this->isAlwaysHashed($key)) {
+            $this->add($manifest, $key, ['sha256' => null, 'size' => $size, 'mtime' => $mtime, 'kind' => 'size_only', 'target' => null]);
+            return;
+        }
+
+        if (! is_readable($path)) {
+            $this->add($manifest, $key, ['sha256' => null, 'size' => $size, 'mtime' => $mtime, 'kind' => 'unreadable', 'target' => null]);
+            return;
+        }
+
+        $hash = @hash_file($this->algo, $path);
+        if ($hash === false) {
+            $this->add($manifest, $key, ['sha256' => null, 'size' => $size, 'mtime' => $mtime, 'kind' => 'unreadable', 'target' => null]);
+            return;
+        }
+
+        $this->add($manifest, $key, ['sha256' => $hash, 'size' => $size, 'mtime' => $mtime, 'kind' => 'hashed', 'target' => null]);
+    }
+
+    private function add(array &$manifest, string $key, array $entry): void
+    {
+        $manifest[$key] = $entry;
+        if (++$this->fileCount > $this->maxFiles) {
+            throw new ManifestLimitException("Manifest exceeded max_files ({$this->maxFiles}).");
+        }
+    }
+
+    /**
+     * Diff two manifests. Returns ['new'=>[], 'modified'=>[], 'deleted'=>[]],
+     * each a map of path => current (or prior, for deleted) entry.
+     *
+     * @param  array<string,array>  $base
+     * @param  array<string,array>  $current
+     * @return array{new:array,modified:array,deleted:array}
+     */
+    public static function diff(array $base, array $current): array
+    {
+        $new = [];
+        $modified = [];
+        $deleted = [];
+
+        foreach ($current as $key => $entry) {
+            if (! array_key_exists($key, $base)) {
+                $new[$key] = $entry;
+            } elseif (self::changed($base[$key], $entry)) {
+                $modified[$key] = $entry;
+            }
+        }
+
+        foreach ($base as $key => $entry) {
+            if (! array_key_exists($key, $current)) {
+                $deleted[$key] = $entry;
+            }
+        }
+
+        return ['new' => $new, 'modified' => $modified, 'deleted' => $deleted];
+    }
+
+    private static function changed(array $a, array $b): bool
+    {
+        // Prefer hash comparison when both sides were hashed; otherwise fall
+        // back to size+mtime (oversized/size_only) or kind transition.
+        if (($a['kind'] ?? null) !== ($b['kind'] ?? null)) {
+            return true;
+        }
+
+        if (! empty($a['sha256']) && ! empty($b['sha256'])) {
+            return $a['sha256'] !== $b['sha256'];
+        }
+
+        if (($a['kind'] ?? null) === 'symlink') {
+            return ($a['target'] ?? null) !== ($b['target'] ?? null);
+        }
+
+        return (int) ($a['size'] ?? -1) !== (int) ($b['size'] ?? -1)
+            || (int) ($a['mtime'] ?? -1) !== (int) ($b['mtime'] ?? -1);
+    }
+
+    /**
+     * Stable root hash over the sorted manifest, used to detect tamper and
+     * for off-box attestation (Phase 3).
+     *
+     * @param  array<string,array>  $manifest
+     */
+    public static function rootHash(array $manifest, string $algo = 'sha256'): string
+    {
+        ksort($manifest);
+        $ctx = hash_init($algo);
+        foreach ($manifest as $key => $entry) {
+            hash_update($ctx, $key . ':' . ($entry['sha256'] ?? '') . ':' . ($entry['size'] ?? '') . ':' . ($entry['kind'] ?? '') . "\n");
+        }
+
+        return hash_final($ctx);
+    }
+
+    /**
+     * Flat path => sha256 view (hashed entries only).
+     *
+     * @param  array<string,array>  $manifest
+     * @return array<string,string>
+     */
+    public static function hashes(array $manifest): array
+    {
+        $out = [];
+        foreach ($manifest as $key => $entry) {
+            if (! empty($entry['sha256'])) {
+                $out[$key] = $entry['sha256'];
+            }
+        }
+
+        return $out;
+    }
+
+    private function included(string $key): bool
+    {
+        foreach ($this->include as $pattern) {
+            if (preg_match($this->globToRegex($pattern), $key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function excluded(string $key): bool
+    {
+        foreach ($this->exclude as $pattern) {
+            if (preg_match($this->globToRegex($pattern), $key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isAlwaysHashed(string $key): bool
+    {
+        $ext = strtolower(pathinfo($key, PATHINFO_EXTENSION));
+
+        return $ext !== '' && in_array($ext, $this->alwaysHashExtensions, true);
+    }
+
+    /** Canonical disk-relative POSIX key. */
+    private function key(string $path): string
+    {
+        $path = $this->normalize($path);
+
+        if ($this->keyBase !== '' && str_starts_with($path, $this->keyBase . '/')) {
+            return substr($path, strlen($this->keyBase) + 1);
+        }
+
+        return ltrim($path, '/');
+    }
+
+    private function normalize(string $path): string
+    {
+        return rtrim(str_replace('\\', '/', $path), '/');
+    }
+
+    private function globToRegex(string $glob): string
+    {
+        $escaped = preg_quote($glob, '#');
+
+        $regex = strtr($escaped, [
+            '\*\*/' => '(?:.*/)?',
+            '\*\*' => '.*',
+            '\*' => '[^/]*',
+            '\?' => '[^/]',
+        ]);
+
+        return '#^' . $regex . '$#';
+    }
+}

--- a/src/Services/Integrity/Manifest.php
+++ b/src/Services/Integrity/Manifest.php
@@ -290,19 +290,23 @@ class Manifest
 
     private function included(string $key): bool
     {
-        foreach ($this->include as $pattern) {
-            if (preg_match($this->globToRegex($pattern), $key)) {
-                return true;
-            }
-        }
-
-        return false;
+        return self::matchesAnyGlob($key, $this->include);
     }
 
     private function excluded(string $key): bool
     {
-        foreach ($this->exclude as $pattern) {
-            if (preg_match($this->globToRegex($pattern), $key)) {
+        return self::matchesAnyGlob($key, $this->exclude);
+    }
+
+    /**
+     * True when $key matches any of the given `**`/`*`/`?` glob patterns.
+     *
+     * @param  string[]  $globs
+     */
+    public static function matchesAnyGlob(string $key, array $globs): bool
+    {
+        foreach ($globs as $pattern) {
+            if (preg_match(self::globToRegex($pattern), $key)) {
                 return true;
             }
         }
@@ -334,7 +338,7 @@ class Manifest
         return rtrim(str_replace('\\', '/', $path), '/');
     }
 
-    private function globToRegex(string $glob): string
+    private static function globToRegex(string $glob): string
     {
         $escaped = preg_quote($glob, '#');
 

--- a/src/Services/Integrity/ManifestLimitException.php
+++ b/src/Services/Integrity/ManifestLimitException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace OzanKurt\Shield\Services\Integrity;
+
+use RuntimeException;
+
+/**
+ * Thrown when a manifest walk exceeds its configured file or iteration cap.
+ * The scanner catches this and records the run as status=aborted_limit rather
+ * than hanging or silently truncating.
+ */
+class ManifestLimitException extends RuntimeException
+{
+}

--- a/src/Services/Integrity/SeverityColor.php
+++ b/src/Services/Integrity/SeverityColor.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace OzanKurt\Shield\Services\Integrity;
+
+/**
+ * Maps a severity name to a hex colour, shared by all notification channels so
+ * the integrity card reads consistently across mail / Slack / Discord.
+ */
+class SeverityColor
+{
+    public const MAP = [
+        'critical' => '8b0000',  // dark red
+        'high' => 'e32929',      // red
+        'medium' => 'fd6a02',    // orange
+        'low' => '2b6cb0',       // blue
+        'all_clear' => '0b6623', // green
+        'info' => '6c757d',      // gray
+    ];
+
+    public const DEFAULT = '6c757d';
+
+    public static function hex(string $severity): string
+    {
+        return self::MAP[$severity] ?? self::DEFAULT;
+    }
+}

--- a/src/Services/Integrity/SeverityColor.php
+++ b/src/Services/Integrity/SeverityColor.php
@@ -11,7 +11,7 @@ class SeverityColor
     public const MAP = [
         'critical' => '8b0000',  // dark red
         'high' => 'e32929',      // red
-        'medium' => 'fd6a02',    // orange
+        'medium' => 'fd6a02', // orange
         'low' => '2b6cb0',       // blue
         'all_clear' => '0b6623', // green
         'info' => '6c757d',      // gray

--- a/src/Services/Integrity/SeverityRuleEvaluator.php
+++ b/src/Services/Integrity/SeverityRuleEvaluator.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace OzanKurt\Shield\Services\Integrity;
+
+/**
+ * Evaluates the ordered, first-match severity rules from config against a single
+ * change. Each rule's `when` is an AND of the conditions present:
+ *   - path_any:        any of these globs matches the path ({public_docroot} expands)
+ *   - ext_any:         the path extension is one of these
+ *   - change_type_any: the change type is one of these
+ *   - always:          unconditional (the default/fallback rule)
+ */
+class SeverityRuleEvaluator
+{
+    /**
+     * @param  array<int,array>  $rules
+     * @param  array<string,string>  $context  e.g. ['public_docroot' => 'public']
+     */
+    public function __construct(
+        private array $rules,
+        private array $context = []
+    ) {}
+
+    public function evaluate(string $path, string $changeType): string
+    {
+        foreach ($this->rules as $rule) {
+            if ($this->matches($rule['when'] ?? [], $path, $changeType)) {
+                return (string) ($rule['severity'] ?? 'low');
+            }
+        }
+
+        return 'low';
+    }
+
+    private function matches(array $when, string $path, string $changeType): bool
+    {
+        if (! empty($when['always'])) {
+            return true;
+        }
+
+        if (empty($when)) {
+            return false;
+        }
+
+        if (isset($when['change_type_any']) && ! in_array($changeType, (array) $when['change_type_any'], true)) {
+            return false;
+        }
+
+        if (isset($when['ext_any'])) {
+            $ext = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+            $exts = array_map('strtolower', (array) $when['ext_any']);
+            if (! in_array($ext, $exts, true)) {
+                return false;
+            }
+        }
+
+        if (isset($when['path_any']) && ! Manifest::matchesAnyGlob($path, $this->expand((array) $when['path_any']))) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /** @param string[] $globs */
+    private function expand(array $globs): array
+    {
+        $docroot = $this->context['public_docroot'] ?? 'public';
+
+        return array_map(fn ($g) => str_replace('{public_docroot}', $docroot, $g), $globs);
+    }
+}

--- a/src/Services/Network/TrustedProxiesService.php
+++ b/src/Services/Network/TrustedProxiesService.php
@@ -31,7 +31,7 @@ class TrustedProxiesService
                 $proxies = array_merge($proxies, $this->fetchCloudflareRanges());
             }
 
-            // AWS and GCP loaders are placeholders — pulling official JSON
+            // AWS and GCP loaders are placeholders, pulling official JSON
             // can be implemented when needed.
 
             $extra = (array) config('shield.trusted_proxies.extra', []);
@@ -53,7 +53,7 @@ class TrustedProxiesService
                 $out = array_merge($out, array_filter(array_map('trim', preg_split('/\r?\n/', $v6->body()) ?: [])));
             }
         } catch (Throwable) {
-            // ignore — fallback to whatever's already in config
+            // ignore, fallback to whatever's already in config
         }
         return $out;
     }

--- a/src/Services/Premium/CentralClient.php
+++ b/src/Services/Premium/CentralClient.php
@@ -84,7 +84,7 @@ class CentralClient
     }
 
     /**
-     * Heartbeat ping — summary stats so Central can show "last seen" +
+     * Heartbeat ping, summary stats so Central can show "last seen" +
      * per-site activity for license holders.
      *
      * @param array<string,mixed> $stats
@@ -106,7 +106,7 @@ class CentralClient
     }
 
     /**
-     * Connectivity test — Central echoes the timestamp back signed
+     * Connectivity test, Central echoes the timestamp back signed
      * with the same secret. Lets the operator confirm both directions
      * of the signing scheme are wired correctly.
      */
@@ -172,9 +172,9 @@ class CentralClient
     /**
      * Resolve the test/ping URL. Three sources, in precedence:
      *   1. Explicit shield.premium.test_ping_url (or LS_PREMIUM_TEST_PING_URL)
-     *   2. Heartbeat URL via path replacement — works for the default
+     *   2. Heartbeat URL via path replacement, works for the default
      *      https://laravel-shield.ozankurt.com/api/heartbeat shape
-     *   3. License-check URL via path replacement — fallback when only
+     *   3. License-check URL via path replacement, fallback when only
      *      the license URL is configured
      *
      * Each candidate is parsed; we reconstruct scheme+host (+port if non-
@@ -225,7 +225,7 @@ class CentralClient
             return DeliveryResult::skipped('no_signing_secret');
         }
 
-        // Encode once — both the signature and the actual request body
+        // Encode once, both the signature and the actual request body
         // hash THIS exact byte sequence. Re-encoding later (even with
         // the same flags) can produce different bytes for floats/etc.
         $body = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
@@ -269,7 +269,7 @@ class CentralClient
      * Open a WebhookDelivery row in pending status BEFORE the HTTP call
      * fires. If the process crashes mid-request (timeout, OOM, etc),
      * the row stays in 'pending' as a permanent record that something
-     * went wrong — invisible failures are debugging hell.
+     * went wrong, invisible failures are debugging hell.
      *
      * Falls back to null silently if the table doesn't exist yet
      * (fresh install pre-migration) so we don't block the actual POST.
@@ -298,7 +298,7 @@ class CentralClient
     }
 
     /**
-     * Update the pending row with the final outcome. Best-effort —
+     * Update the pending row with the final outcome. Best-effort -
      * if the row is missing we still return the result unchanged.
      */
     private function finalize(?WebhookDelivery $delivery, DeliveryResult $result): DeliveryResult
@@ -319,7 +319,7 @@ class CentralClient
                 $result->responseExcerpt,
             );
         } catch (\Throwable) {
-            // Cosmetic — don't break the actual delivery on a logging miss.
+            // Cosmetic, don't break the actual delivery on a logging miss.
         }
 
         return $result;

--- a/src/Services/Premium/DeliveryResult.php
+++ b/src/Services/Premium/DeliveryResult.php
@@ -64,7 +64,7 @@ final class DeliveryResult
             return false;
         }
         // Retry on connection failures + 5xx; 4xx is permanent (signature
-        // wrong, license inactive, payload malformed — won't fix by retry).
+        // wrong, license inactive, payload malformed, won't fix by retry).
         return $this->httpStatus === 0 || $this->httpStatus >= 500;
     }
 

--- a/src/Services/Premium/LicenseChecker.php
+++ b/src/Services/Premium/LicenseChecker.php
@@ -23,7 +23,7 @@ use Illuminate\Support\Facades\Log;
  * The license key is treated as a secret: it never appears in logs,
  * exception messages, or rendered dashboard output in clear text.
  *
- * The check is SOFT ENFORCEMENT — by design. Real value is server-side
+ * The check is SOFT ENFORCEMENT, by design. Real value is server-side
  * (Central API gates downloads, queue priority, etc.). The local class
  * is a thin client that lets honest buyers see status + grace banners.
  */
@@ -89,7 +89,7 @@ class LicenseChecker
      *
      * NOTE: this method may trigger a synchronous HTTP call to Central
      * on a cache miss (up to http_timeout seconds). DO NOT use it in a
-     * hot path (every request, every audit log, etc.) — use cachedState()
+     * hot path (every request, every audit log, etc.), use cachedState()
      * for fast, cache-only reads in those places.
      *
      * @return array{state: string, valid: bool, reason?: string, expires_at?: string|null, plan?: string|null, features?: array<int,string>, domain_limit?: int|null, domains_used?: int|null, last_checked_at?: string, grace_until?: string|null}
@@ -113,7 +113,7 @@ class LicenseChecker
      * license badge, AuditLogger's per-write Central forward gate, etc.
      *
      * Returns null when no cache entry exists (e.g. fresh deploy, cache
-     * flush). Callers should treat null as "premium unknown — assume off
+     * flush). Callers should treat null as "premium unknown, assume off
      * for safety; refresh will happen on the next cron/Artisan call".
      *
      * @return array<string,mixed>|null
@@ -126,7 +126,7 @@ class LicenseChecker
 
     /**
      * Fast cached-only premium check for hot paths. Returns false when
-     * the cache is empty rather than hitting Central — safe-by-default
+     * the cache is empty rather than hitting Central, safe-by-default
      * (premium features off until a background refresh populates the
      * cache via cron/Artisan).
      */
@@ -326,7 +326,7 @@ class LicenseChecker
         ]);
 
         // Fresh install OR previously-INVALID state hitting an unreachable
-        // Central — we have no prior valid check to anchor grace on. Use a
+        // Central, we have no prior valid check to anchor grace on. Use a
         // short retry TTL (5 min) so a transient outage at install time
         // doesn't trap a new buyer in STATE_INVALID for the full 24h cache_ttl.
         // The state is still INVALID (premium features off), but the next
@@ -356,7 +356,7 @@ class LicenseChecker
         }
 
         // STATE_GRACE preserves last_valid_at; STATE_VALID's own check was
-        // the valid one — use its last_checked_at.
+        // the valid one, use its last_checked_at.
         if (($previous['state'] ?? null) === self::STATE_GRACE) {
             return $previous['last_valid_at'] ?? null;
         }
@@ -382,7 +382,7 @@ class LicenseChecker
 
     /**
      * Persist with an explicit TTL. Used by persistGraceOrInvalid to give
-     * a short retry window when no prior valid check exists — preventing
+     * a short retry window when no prior valid check exists, preventing
      * the new-install Central-outage trap where a fresh buyer gets stuck
      * in STATE_INVALID for 24h after a transient API blip at install time.
      *
@@ -419,7 +419,7 @@ class LicenseChecker
         // THREE directories up (verified: __DIR__/../../../ = package
         // root). Note: composer.json doesn't ship a "version" field in
         // package.json (it's generated from Git tags), so this typically
-        // returns "unknown" anyway — but the path itself is correct.
+        // returns "unknown" anyway, but the path itself is correct.
         $composerJson = __DIR__ . '/../../../composer.json';
 
         if (is_file($composerJson)) {

--- a/src/Services/Premium/WebhookSigner.php
+++ b/src/Services/Premium/WebhookSigner.php
@@ -24,13 +24,13 @@ namespace OzanKurt\Shield\Services\Premium;
  *   X-Shield-Nonce:     <nonce>
  *
  * The body itself is hashed (not included in the signed message) so we
- * don't need to canonicalise JSON whitespace — both sides hash the
+ * don't need to canonicalise JSON whitespace, both sides hash the
  * exact raw bytes. Central is responsible for capturing the raw body
  * BEFORE Laravel re-encodes it (via the file_get_contents('php://input')
  * fallback in the verifier).
  *
  * Secret precedence:
- *   1. LS_PREMIUM_WEBHOOK_SECRET (if set — preferred for rotation)
+ *   1. LS_PREMIUM_WEBHOOK_SECRET (if set, preferred for rotation)
  *   2. LS_PREMIUM_LICENSE_KEY (fallback so v2.0 deployments still sign)
  */
 class WebhookSigner
@@ -42,7 +42,7 @@ class WebhookSigner
 
     /**
      * Compute the headers for a signed request. Caller must POST the
-     * EXACT $body string we hash here — do NOT re-encode after this
+     * EXACT $body string we hash here, do NOT re-encode after this
      * call or the signature won't match.
      *
      * @return array<string, string>
@@ -80,7 +80,7 @@ class WebhookSigner
 
     /**
      * Resolve the signing secret. Separate webhook secret takes
-     * precedence over the license key — operators rotate the webhook
+     * precedence over the license key, operators rotate the webhook
      * secret on incident response without revoking the whole license.
      */
     private function secret(): ?string

--- a/src/Services/Scanner/Quarantine.php
+++ b/src/Services/Scanner/Quarantine.php
@@ -13,15 +13,15 @@ use RuntimeException;
  * Moves and restores files based on per-target quarantine policy.
  *
  * Policy is one of:
- *   'move_and_stub'  — moves the file to the quarantine dir, writes an empty stub at the
+ *   'move_and_stub' , moves the file to the quarantine dir, writes an empty stub at the
  *                       original path so subsequent scans see "the file" exists but has no
  *                       executable content. Reversible via restore().
- *   'log_only'        — never touches the file. Used for app_files / vendor where mutation
+ *   'log_only'       , never touches the file. Used for app_files / vendor where mutation
  *                       would break the running app.
  *
  * Storage layout:
- *   storage/shield/quarantine/<finding-uuid>.bin       — the original file contents
- *   storage/shield/quarantine/<finding-uuid>.json      — sidecar metadata (original path, mtime, perms)
+ *   storage/shield/quarantine/<finding-uuid>.bin      , the original file contents
+ *   storage/shield/quarantine/<finding-uuid>.json     , sidecar metadata (original path, mtime, perms)
  */
 class Quarantine
 {

--- a/src/Services/ThreatFeed/FeedRunner.php
+++ b/src/Services/ThreatFeed/FeedRunner.php
@@ -67,11 +67,11 @@ class FeedRunner
     }
 
     /**
-     * Gate check — providers in PREMIUM_ONLY_PROVIDERS require a valid
+     * Gate check, providers in PREMIUM_ONLY_PROVIDERS require a valid
      * premium license. Other providers always run if they report
      * isAvailable() = true.
      *
-     * Falls open if isFeatureAvailable() throws — better to skip a
+     * Falls open if isFeatureAvailable() throws, better to skip a
      * premium provider than to crash the cron job.
      */
     private function isProviderUnlocked(ThreatFeedProvider $provider): bool

--- a/src/Services/ThreatFeed/Providers/MaxMindGeoLite2Provider.php
+++ b/src/Services/ThreatFeed/Providers/MaxMindGeoLite2Provider.php
@@ -12,7 +12,7 @@ use OzanKurt\Shield\Services\ThreatFeed\SyncResult;
  * storage/shield/geo/. Requires LS_MAXMIND_LICENSE_KEY (free signup
  * required at maxmind.com).
  *
- * Doesn't write any ACL/WAF rows itself — once the DBs are in place,
+ * Doesn't write any ACL/WAF rows itself, once the DBs are in place,
  * the CountryMatcher / AsnMatcher stubs from beta.1 swap to real
  * implementations driven by geoip2/geoip2 reader.
  */

--- a/src/Shield.php
+++ b/src/Shield.php
@@ -94,7 +94,7 @@ class Shield
 
     /**
      * Is a premium license active? Cached 24h, with a 7-day grace period
-     * if the Central license-check API is unreachable. Soft enforcement —
+     * if the Central license-check API is unreachable. Soft enforcement -
      * see Services\Premium\LicenseChecker for the rationale.
      */
     public function isPremium(): bool
@@ -115,7 +115,7 @@ class Shield
     /**
      * Full license state for the License dashboard page. Includes plan,
      * expiry, domain limit + count, last-checked timestamp, and grace
-     * status. License key itself is NOT exposed — use maskedKey() instead.
+     * status. License key itself is NOT exposed, use maskedKey() instead.
      *
      * MAY trigger a synchronous HTTP call to Central on cache miss. Use
      * licenseStateCached() in views/middleware/hot paths to avoid that.
@@ -129,7 +129,7 @@ class Shield
 
     /**
      * Cache-only license state for hot paths (navbar badge, every-request
-     * checks, etc.). Returns null when no cache entry exists — callers
+     * checks, etc.). Returns null when no cache entry exists, callers
      * should render a neutral state, NEVER trigger a refresh from here.
      *
      * @return array<string,mixed>|null

--- a/src/ShieldServiceProvider.php
+++ b/src/ShieldServiceProvider.php
@@ -273,6 +273,8 @@ class ShieldServiceProvider extends ServiceProvider
         $this->commands(\OzanKurt\Shield\Console\Commands\ScanCommand::class);
         $this->commands(\OzanKurt\Shield\Console\Commands\ScanStatusCommand::class);
         $this->commands(\OzanKurt\Shield\Console\Commands\ScanCancelCommand::class);
+        $this->commands(\OzanKurt\Shield\Console\Commands\IntegrityScanCommand::class);
+        $this->commands(\OzanKurt\Shield\Console\Commands\IntegrityBlessCommand::class);
         $this->commands(\OzanKurt\Shield\Console\Commands\QuarantineListCommand::class);
         $this->commands(\OzanKurt\Shield\Console\Commands\QuarantineRestoreCommand::class);
         $this->commands(\OzanKurt\Shield\Console\Commands\ClamavStatusCommand::class);
@@ -305,6 +307,13 @@ class ShieldServiceProvider extends ServiceProvider
                 app(Schedule::class)
                     ->command('shield:audit-drift')
                     ->cron(config('shield.audit.drift.cron', '0 4 * * *'));
+            }
+
+            if (config('shield.integrity.schedule.enabled', false)) {
+                app(Schedule::class)
+                    ->command('shield:integrity')
+                    ->cron(config('shield.integrity.schedule.cron', '0 * * * *'))
+                    ->withoutOverlapping();
             }
 
             app(Schedule::class)

--- a/src/ShieldServiceProvider.php
+++ b/src/ShieldServiceProvider.php
@@ -175,6 +175,13 @@ class ShieldServiceProvider extends ServiceProvider
             $router->get('scanner/signatures', [\OzanKurt\Shield\Http\Controllers\ScannerController::class, 'signatures'])->name('scanner.signatures');
             $router->post('scanner/run', [\OzanKurt\Shield\Http\Controllers\ScannerController::class, 'startScan'])->name('scanner.run');
 
+            // File integrity
+            $router->get('integrity', [\OzanKurt\Shield\Http\Controllers\IntegrityController::class, 'index'])->name('integrity.index');
+            $router->get('integrity/runs', [\OzanKurt\Shield\Http\Controllers\IntegrityController::class, 'runs'])->name('integrity.runs');
+            $router->get('integrity/changes', [\OzanKurt\Shield\Http\Controllers\IntegrityController::class, 'changes'])->name('integrity.changes');
+            $router->post('integrity/scan', [\OzanKurt\Shield\Http\Controllers\IntegrityController::class, 'scan'])->name('integrity.scan');
+            $router->post('integrity/bless', [\OzanKurt\Shield\Http\Controllers\IntegrityController::class, 'bless'])->name('integrity.bless');
+
             // Threat feed
             $router->get('threat-feed', function () {
                 return app(\OzanKurt\Shield\Http\Controllers\ThreatFeedController::class)->index(

--- a/src/ShieldServiceProvider.php
+++ b/src/ShieldServiceProvider.php
@@ -101,7 +101,7 @@ class ShieldServiceProvider extends ServiceProvider
         $this->publishAssets();
 
         // Auto-load all package-shipped migrations. Consumer apps no longer
-        // need to publish migration stubs to run them — they execute from
+        // need to publish migration stubs to run them, they execute from
         // the vendor directory on `php artisan migrate` like Sanctum/Telescope.
         $this->loadMigrationsFrom(__DIR__ . '/../database/migrations');
 
@@ -374,7 +374,7 @@ class ShieldServiceProvider extends ServiceProvider
                     ->cron($this->minutesToCron($minutes));
             }
 
-            // Background license refresh — keeps the LicenseChecker cache
+            // Background license refresh, keeps the LicenseChecker cache
             // warm so hot paths (navbar, AuditLogger) can use the cache-only
             // path without ever triggering a synchronous HTTP call to Central.
             // Fires once an hour; LicenseChecker still respects the per-state
@@ -406,8 +406,8 @@ class ShieldServiceProvider extends ServiceProvider
      * like /wp-admin, /.env, /phpmyadmin etc.
      *
      * Each configured path registers TWO routes:
-     *   1. Exact match  — /wp-admin
-     *   2. Subpath match — /wp-admin/{any} where {any} matches anything
+     *   1. Exact match , /wp-admin
+     *   2. Subpath match, /wp-admin/{any} where {any} matches anything
      *
      * Both fire the same controller. Subpath match catches probes like
      * /wp-admin/install.php, /.git/HEAD, /phpmyadmin/scripts/setup.php.
@@ -427,7 +427,7 @@ class ShieldServiceProvider extends ServiceProvider
             // Exact path
             $router->any('/' . $trimmed, [$controller, 'trap']);
 
-            // Subpath wildcard — /<path>/<anything>
+            // Subpath wildcard, /<path>/<anything>
             $router->any('/' . $trimmed . '/{any}', [$controller, 'trap'])
                 ->where('any', '.*');
         }
@@ -486,7 +486,7 @@ class ShieldServiceProvider extends ServiceProvider
     /**
      * Turn an interval in minutes into a cron expression. Only intervals
      * that evenly divide 60 produce a uniform schedule. For non-divisors
-     * we round UP to the next divisor — the cron syntax has no way to
+     * we round UP to the next divisor, the cron syntax has no way to
      * express "every 7 minutes" without drift at the hour boundary, and
      * users typically prefer a slightly slower-but-uniform schedule over
      * an irregular one (e.g. 7→10 minutes, 25→30).

--- a/src/ShieldServiceProvider.php
+++ b/src/ShieldServiceProvider.php
@@ -286,6 +286,9 @@ class ShieldServiceProvider extends ServiceProvider
         $this->commands(\OzanKurt\Shield\Console\Commands\ScanCancelCommand::class);
         $this->commands(\OzanKurt\Shield\Console\Commands\IntegrityScanCommand::class);
         $this->commands(\OzanKurt\Shield\Console\Commands\IntegrityBlessCommand::class);
+        $this->commands(\OzanKurt\Shield\Console\Commands\IntegrityStatusCommand::class);
+        $this->commands(\OzanKurt\Shield\Console\Commands\IntegrityPruneCommand::class);
+        $this->commands(\OzanKurt\Shield\Console\Commands\IntegrityHeartbeatCommand::class);
         $this->commands(\OzanKurt\Shield\Console\Commands\QuarantineListCommand::class);
         $this->commands(\OzanKurt\Shield\Console\Commands\QuarantineRestoreCommand::class);
         $this->commands(\OzanKurt\Shield\Console\Commands\ClamavStatusCommand::class);
@@ -325,6 +328,17 @@ class ShieldServiceProvider extends ServiceProvider
                     ->command('shield:integrity')
                     ->cron(config('shield.integrity.schedule.cron', '0 * * * *'))
                     ->withoutOverlapping();
+
+                app(Schedule::class)
+                    ->command('shield:integrity-prune')
+                    ->daily();
+
+                if (config('shield.integrity.heartbeat.enabled', true)) {
+                    app(Schedule::class)
+                        ->command('shield:integrity-heartbeat')
+                        ->hourly()
+                        ->withoutOverlapping();
+                }
             }
 
             app(Schedule::class)

--- a/src/ShieldServiceProvider.php
+++ b/src/ShieldServiceProvider.php
@@ -249,6 +249,10 @@ class ShieldServiceProvider extends ServiceProvider
         $this->app['events']->listen(AttackDetectedEvent::class, AttackDetectedListener::class);
         $this->app['events']->listen(AuthLoginEvent::class, SuccessfulLoginListener::class);
         $this->app['events']->listen(AuthFailedEvent::class, FailedLoginListener::class);
+        $this->app['events']->listen(
+            \OzanKurt\Shield\Events\IntegrityScanCompletedEvent::class,
+            \OzanKurt\Shield\Listeners\IntegrityScanCompletedListener::class
+        );
 
         \OzanKurt\Shield\Models\Acl::observe(\OzanKurt\Shield\Observers\AclObserver::class);
         \OzanKurt\Shield\Models\WafRule::observe(\OzanKurt\Shield\Observers\WafRuleObserver::class);

--- a/src/Support/RequestDataRedactor.php
+++ b/src/Support/RequestDataRedactor.php
@@ -6,9 +6,9 @@ namespace OzanKurt\Shield\Support;
  * Redact sensitive fields from request data before persistence.
  *
  * Config:
- *   shield.redaction.keys         — list of key patterns (supports wildcards)
- *   shield.redaction.placeholder  — replacement value (default '[redacted]')
- *   shield.redaction.use_regex    — when true, '*' in a key is treated as ".*" regex
+ *   shield.redaction.keys        , list of key patterns (supports wildcards)
+ *   shield.redaction.placeholder , replacement value (default '[redacted]')
+ *   shield.redaction.use_regex   , when true, '*' in a key is treated as ".*" regex
  */
 class RequestDataRedactor
 {

--- a/tests/Feature/BypassMechanismTest.php
+++ b/tests/Feature/BypassMechanismTest.php
@@ -100,7 +100,7 @@ class BypassMechanismTest extends TestCase
 
         $this->artisan('shield:bypass-remove', ['ip' => '10.0.0.2'])->assertSuccessful();
 
-        // Acl uses SoftDeletes — the row is retained but deleted_at is set
+        // Acl uses SoftDeletes, the row is retained but deleted_at is set
         $this->assertDatabaseMissing('ls_acl', ['value' => '10.0.0.2', 'source' => 'bypass', 'deleted_at' => null]);
     }
 

--- a/tests/Feature/Integrity/IntegrityCommandsTest.php
+++ b/tests/Feature/Integrity/IntegrityCommandsTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace OzanKurt\Shield\Tests\Feature\Integrity;
+
+use OzanKurt\Shield\Models\IntegrityChange;
+use OzanKurt\Shield\Models\IntegrityRun;
+use OzanKurt\Shield\Models\Lookups\IntegrityChangeType;
+use OzanKurt\Shield\Models\Lookups\IntegrityComparisonBasis;
+use OzanKurt\Shield\Models\Lookups\IntegrityStatus;
+use OzanKurt\Shield\Models\Lookups\ScannerTrigger;
+use OzanKurt\Shield\Services\Integrity\IntegrityScanner;
+use OzanKurt\Shield\Tests\TestCase;
+
+class IntegrityCommandsTest extends TestCase
+{
+    private string $src;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->src = sys_get_temp_dir() . '/shield_cmd_src_' . uniqid();
+        @mkdir($this->src . '/app', 0777, true);
+        file_put_contents($this->src . '/app/Service.php', '<?php // v1');
+
+        config([
+            'shield.integrity.baseline.hmac_key' => 'test-key',
+            'shield.integrity.disks.test' => [
+                'roots' => [$this->src],
+                'key_base' => $this->src,
+                'include' => ['**/*'],
+                'exclude' => [],
+                'follow_symlinks' => false,
+                'max_file_size' => 50 * 1024 * 1024,
+            ],
+        ]);
+
+        $this->deleteTree(storage_path('shield/integrity/test'));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTree($this->src);
+        $this->deleteTree(storage_path('shield/integrity/test'));
+        parent::tearDown();
+    }
+
+    public function test_status_command_succeeds_after_a_scan(): void
+    {
+        (new IntegrityScanner())->run('test', 'manual');
+
+        $this->artisan('shield:integrity-status', ['--disk' => 'test'])->assertSuccessful();
+    }
+
+    public function test_heartbeat_fails_when_there_is_no_recent_run(): void
+    {
+        $this->artisan('shield:integrity-heartbeat', ['--disk' => 'test'])->assertExitCode(1);
+    }
+
+    public function test_heartbeat_succeeds_after_a_scan(): void
+    {
+        (new IntegrityScanner())->run('test', 'manual');
+
+        $this->artisan('shield:integrity-heartbeat', ['--disk' => 'test'])->assertExitCode(0);
+    }
+
+    public function test_prune_deletes_runs_and_changes_past_retention(): void
+    {
+        $run = IntegrityRun::create([
+            'status_id' => IntegrityStatus::where('name', 'completed')->value('id'),
+            'trigger_id' => ScannerTrigger::where('name', 'manual')->value('id'),
+            'disk' => 'test',
+        ]);
+        $change = IntegrityChange::create([
+            'integrity_run_id' => $run->id,
+            'change_type_id' => IntegrityChangeType::where('name', 'new')->value('id'),
+            'compared_to_id' => IntegrityComparisonBasis::where('name', 'last_run')->value('id'),
+            'path' => 'app/Old.php',
+        ]);
+
+        // Backdate beyond retention (runs_days default 90).
+        IntegrityRun::where('id', $run->id)->update(['created_at' => now()->subDays(200)]);
+        IntegrityChange::where('id', $change->id)->update(['created_at' => now()->subDays(200)]);
+
+        $this->artisan('shield:integrity-prune')->assertSuccessful();
+
+        $this->assertFalse(IntegrityRun::where('id', $run->id)->exists());
+        $this->assertFalse(IntegrityChange::where('id', $change->id)->exists());
+    }
+
+    private function deleteTree(string $dir): void
+    {
+        if (! is_dir($dir)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($items as $item) {
+            if ($item->isLink() || $item->isFile()) {
+                @unlink($item->getPathname());
+            } else {
+                @rmdir($item->getPathname());
+            }
+        }
+        @rmdir($dir);
+    }
+}

--- a/tests/Feature/Integrity/IntegrityDashboardTest.php
+++ b/tests/Feature/Integrity/IntegrityDashboardTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace OzanKurt\Shield\Tests\Feature\Integrity;
+
+use Illuminate\Support\Facades\Gate;
+use OzanKurt\Shield\Models\IntegrityRun;
+use OzanKurt\Shield\Tests\TestCase;
+
+class IntegrityDashboardTest extends TestCase
+{
+    private string $src;
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        parent::getEnvironmentSetUp($app);
+        $app['config']->set('app.key', 'base64:Lf+1x2r3feOZ2hfF6Ksn6JSwbR4yGJ3vYri6EGr/EuA=');
+        $app['config']->set('shield.dashboard.enabled', true);
+        $app['config']->set('shield.dashboard.middleware', []); // drop auth for the test
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Gate::define('viewShieldDashboard', fn () => true);
+
+        $this->src = sys_get_temp_dir() . '/shield_dash_src_' . uniqid();
+        @mkdir($this->src . '/app', 0777, true);
+        file_put_contents($this->src . '/app/Service.php', '<?php // v1');
+
+        config([
+            'shield.integrity.baseline.hmac_key' => 'test-key',
+            'shield.integrity.disks.test' => [
+                'roots' => [$this->src],
+                'key_base' => $this->src,
+                'include' => ['**/*'],
+                'exclude' => [],
+                'follow_symlinks' => false,
+                'max_file_size' => 50 * 1024 * 1024,
+            ],
+        ]);
+
+        $this->deleteTree(storage_path('shield/integrity/test'));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTree($this->src);
+        $this->deleteTree(storage_path('shield/integrity/test'));
+        parent::tearDown();
+    }
+
+    public function test_integrity_index_renders(): void
+    {
+        $this->get(route('shield.integrity.index'))
+            ->assertOk()
+            ->assertSee('File integrity');
+    }
+
+    public function test_runs_datatable_returns_json(): void
+    {
+        $this->get(route('shield.integrity.runs', ['mode' => 'dataTable']))
+            ->assertOk()
+            ->assertJsonStructure(['draw', 'recordsTotal', 'recordsFiltered', 'data']);
+    }
+
+    public function test_changes_datatable_returns_json(): void
+    {
+        $this->get(route('shield.integrity.changes', ['mode' => 'dataTable']))
+            ->assertOk()
+            ->assertJsonStructure(['draw', 'recordsTotal', 'recordsFiltered', 'data']);
+    }
+
+    public function test_scan_action_runs_and_persists_a_run(): void
+    {
+        $this->post(route('shield.integrity.scan'), ['disk' => 'test'])
+            ->assertOk()
+            ->assertJsonStructure(['actions']);
+
+        $this->assertTrue(IntegrityRun::where('disk', 'test')->exists());
+    }
+
+    public function test_bless_without_a_prior_run_returns_an_error_toastr(): void
+    {
+        $response = $this->post(route('shield.integrity.bless'), ['disk' => 'test'])->assertOk();
+
+        $actions = $response->json('actions');
+        $this->assertSame('error', $actions[0]['data']['type']);
+    }
+
+    private function deleteTree(string $dir): void
+    {
+        if (! is_dir($dir)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($items as $item) {
+            if ($item->isLink() || $item->isFile()) {
+                @unlink($item->getPathname());
+            } else {
+                @rmdir($item->getPathname());
+            }
+        }
+        @rmdir($dir);
+    }
+}

--- a/tests/Feature/Integrity/IntegrityDataLayerTest.php
+++ b/tests/Feature/Integrity/IntegrityDataLayerTest.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace OzanKurt\Shield\Tests\Feature\Integrity;
+
+use Illuminate\Support\Carbon;
+use OzanKurt\Shield\Models\IntegrityBaseline;
+use OzanKurt\Shield\Models\IntegrityChange;
+use OzanKurt\Shield\Models\IntegrityRun;
+use OzanKurt\Shield\Models\Lookups\IntegrityChangeType;
+use OzanKurt\Shield\Models\Lookups\IntegrityComparisonBasis;
+use OzanKurt\Shield\Models\Lookups\IntegrityStatus;
+use OzanKurt\Shield\Models\Lookups\LogLevel;
+use OzanKurt\Shield\Models\Lookups\ScannerTrigger;
+use OzanKurt\Shield\Tests\TestCase;
+
+class IntegrityDataLayerTest extends TestCase
+{
+    public function test_integrity_lookups_are_seeded(): void
+    {
+        $this->assertSame(10, IntegrityStatus::count());
+        $this->assertSame(8, IntegrityChangeType::count());
+        $this->assertSame(2, IntegrityComparisonBasis::count());
+
+        $this->assertNotNull(IntegrityStatus::where('name', 'baseline_established')->first());
+        $this->assertNotNull(IntegrityChangeType::where('name', 'scope_changed')->first());
+        $this->assertNotNull(IntegrityComparisonBasis::where('name', 'known_good')->first());
+    }
+
+    public function test_integrity_run_persists_with_uuid_and_resolves_lookups(): void
+    {
+        $run = IntegrityRun::create([
+            'status_id' => IntegrityStatus::where('name', 'completed')->value('id'),
+            'trigger_id' => ScannerTrigger::where('name', 'scheduled')->value('id'),
+            'severity_id' => LogLevel::where('name', 'high')->value('id'),
+            'disk' => 'app',
+            'files_total' => 92106,
+            'count_new' => 8,
+            'count_modified' => 2,
+            'count_deleted' => 0,
+            'started_at' => now(),
+            'finished_at' => now(),
+        ]);
+
+        $fresh = $run->fresh();
+
+        $this->assertNotEmpty($fresh->uuid);
+        $this->assertSame('completed', $fresh->status->name);
+        $this->assertSame('scheduled', $fresh->trigger->name);
+        $this->assertSame('high', $fresh->severity->name);
+        $this->assertSame(92106, $fresh->files_total);
+    }
+
+    public function test_integrity_change_links_to_run_and_lookups(): void
+    {
+        $run = IntegrityRun::create([
+            'status_id' => IntegrityStatus::where('name', 'completed')->value('id'),
+            'trigger_id' => ScannerTrigger::where('name', 'scheduled')->value('id'),
+            'disk' => 'app',
+        ]);
+
+        $change = IntegrityChange::create([
+            'integrity_run_id' => $run->id,
+            'change_type_id' => IntegrityChangeType::where('name', 'new')->value('id'),
+            'compared_to_id' => IntegrityComparisonBasis::where('name', 'last_run')->value('id'),
+            'severity_id' => LogLevel::where('name', 'critical')->value('id'),
+            'path' => 'public/cache/ff/3776/footer.php',
+            'new_hash' => str_repeat('a', 64),
+            'size_bytes' => 1234,
+        ]);
+
+        $this->assertNotEmpty($change->uuid);
+        $this->assertSame($run->id, $change->run->id);
+        $this->assertSame('new', $change->changeType->name);
+        $this->assertSame('last_run', $change->comparedTo->name);
+        $this->assertSame('critical', $change->severity->name);
+        $this->assertSame(1, $run->changes()->count());
+    }
+
+    public function test_integrity_baseline_casts_and_uuid(): void
+    {
+        $baseline = IntegrityBaseline::create([
+            'disk' => 'app',
+            'scope_fingerprint' => 'abc123',
+            'root_hash' => str_repeat('b', 64),
+            'artifact_path' => 'shield/integrity/app/baseline.ndjson.gz',
+            'files_total' => 92106,
+            'signed' => true,
+            'blessed_at' => now(),
+        ]);
+
+        $fresh = $baseline->fresh();
+
+        $this->assertNotEmpty($fresh->uuid);
+        $this->assertTrue($fresh->signed);
+        $this->assertSame(92106, $fresh->files_total);
+        $this->assertInstanceOf(Carbon::class, $fresh->blessed_at);
+    }
+}

--- a/tests/Feature/Integrity/IntegrityNotificationTest.php
+++ b/tests/Feature/Integrity/IntegrityNotificationTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace OzanKurt\Shield\Tests\Feature\Integrity;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Notification;
+use OzanKurt\Shield\Models\IntegrityRun;
+use OzanKurt\Shield\Notifications\IntegrityScanCompletedNotification;
+use OzanKurt\Shield\Notifications\Notifiable;
+use OzanKurt\Shield\Services\Integrity\IntegrityScanner;
+use OzanKurt\Shield\Tests\TestCase;
+
+class IntegrityNotificationTest extends TestCase
+{
+    private string $src;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Http::fake(); // never hit a real webhook
+
+        $this->src = sys_get_temp_dir() . '/shield_notif_src_' . uniqid();
+        @mkdir($this->src . '/app', 0777, true);
+        file_put_contents($this->src . '/app/Service.php', '<?php // v1');
+
+        config([
+            'shield.integrity.baseline.hmac_key' => 'test-key',
+            'shield.integrity.disks.test' => [
+                'roots' => [$this->src],
+                'key_base' => $this->src,
+                'include' => ['**/*'],
+                'exclude' => [],
+                'follow_symlinks' => false,
+                'max_file_size' => 50 * 1024 * 1024,
+            ],
+            // Channel wired, event toggle off by default so baseline setup runs are quiet.
+            'shield.notification_channels.discord.enabled' => true,
+            'shield.notification_channels.discord.webhook_url' => 'https://discord.com/api/webhooks/1/abc',
+            'shield.notifications.integrity_changed.enabled' => false,
+        ]);
+
+        $this->cleanArtifacts();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTree($this->src);
+        $this->cleanArtifacts();
+        parent::tearDown();
+    }
+
+    private function scanner(): IntegrityScanner
+    {
+        return new IntegrityScanner();
+    }
+
+    public function test_notification_is_sent_when_there_are_changes(): void
+    {
+        $this->scanner()->run('test', 'manual'); // baseline (event toggle off)
+
+        Notification::fake();
+        config(['shield.notifications.integrity_changed.enabled' => true]);
+
+        file_put_contents($this->src . '/app/New.php', '<?php // new');
+        $this->scanner()->run('test', 'scheduled');
+
+        Notification::assertSentTo(
+            new Notifiable(),
+            IntegrityScanCompletedNotification::class,
+            fn ($n) => (int) $n->run->count_new === 1
+        );
+    }
+
+    public function test_notification_is_suppressed_when_no_changes(): void
+    {
+        $this->scanner()->run('test', 'manual'); // baseline
+
+        Notification::fake();
+        config(['shield.notifications.integrity_changed.enabled' => true]);
+
+        $this->scanner()->run('test', 'scheduled'); // nothing changed -> delta 0
+
+        Notification::assertNothingSent();
+    }
+
+    public function test_baseline_established_notifies_even_with_zero_delta(): void
+    {
+        Notification::fake();
+        config(['shield.notifications.integrity_changed.enabled' => true]);
+
+        $this->scanner()->run('test', 'manual'); // first run, security event
+
+        Notification::assertSentTo(new Notifiable(), IntegrityScanCompletedNotification::class);
+    }
+
+    public function test_discord_card_renders_summary_and_severity_colour(): void
+    {
+        $this->scanner()->run('test', 'manual'); // baseline
+        file_put_contents($this->src . '/app/New.php', '<?php // new');
+        $run = $this->scanner()->run('test', 'manual');
+
+        $embed = (new IntegrityScanCompletedNotification(IntegrityRun::find($run->id)))
+            ->toDiscord()
+            ->toArray()['embeds'][0];
+
+        $this->assertStringContainsString('File integrity scan', $embed['title']);
+        $this->assertStringContainsString('1 new', $embed['description']);
+        $this->assertCount(3, $embed['fields']); // New / Modified / Deleted
+        $this->assertIsInt($embed['color']);
+    }
+
+    private function cleanArtifacts(): void
+    {
+        $this->deleteTree(storage_path('shield/integrity/test'));
+    }
+
+    private function deleteTree(string $dir): void
+    {
+        if (! is_dir($dir)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($items as $item) {
+            if ($item->isLink() || $item->isFile()) {
+                @unlink($item->getPathname());
+            } else {
+                @rmdir($item->getPathname());
+            }
+        }
+        @rmdir($dir);
+    }
+}

--- a/tests/Feature/Integrity/IntegrityScannerTest.php
+++ b/tests/Feature/Integrity/IntegrityScannerTest.php
@@ -6,6 +6,7 @@ use Illuminate\Support\Facades\Event;
 use OzanKurt\Shield\Events\IntegrityScanCompletedEvent;
 use OzanKurt\Shield\Models\IntegrityBaseline;
 use OzanKurt\Shield\Models\IntegrityChange;
+use OzanKurt\Shield\Models\Lookups\IntegrityChangeType;
 use OzanKurt\Shield\Services\Integrity\IntegrityScanner;
 use OzanKurt\Shield\Tests\TestCase;
 
@@ -122,6 +123,72 @@ class IntegrityScannerTest extends TestCase
         $this->assertTrue($baseline->signed);
         $this->assertSame('test', $baseline->disk);
         $this->assertSame(1, IntegrityBaseline::where('disk', 'test')->count()); // old row replaced
+    }
+
+    public function test_deleted_file_is_high_severity(): void
+    {
+        $this->scanner()->run('test', 'manual'); // baseline includes app/Service.php
+
+        unlink($this->src . '/app/Service.php');
+
+        $run = $this->scanner()->run('test', 'manual');
+
+        $this->assertSame('high', $run->severity->name);
+
+        $change = IntegrityChange::where('integrity_run_id', $run->id)
+            ->where('path', 'app/Service.php')
+            ->first();
+        $this->assertNotNull($change);
+        $this->assertSame('deleted', $change->changeType->name);
+        $this->assertSame('high', $change->severity->name);
+    }
+
+    public function test_scope_change_is_classified_not_treated_as_deletion(): void
+    {
+        $this->scanner()->run('test', 'manual'); // baseline includes app/Service.php
+
+        // Narrow the scope so app/** leaves the watched set.
+        config(['shield.integrity.disks.test.exclude' => ['app/**']]);
+
+        $run = $this->scanner()->run('test', 'manual');
+
+        $this->assertGreaterThan(0, $run->count_scope_changed);
+
+        $scopeChangedId = IntegrityChangeType::where('name', 'scope_changed')->value('id');
+        $this->assertTrue(
+            IntegrityChange::where('integrity_run_id', $run->id)
+                ->where('change_type_id', $scopeChangedId)
+                ->exists()
+        );
+    }
+
+    public function test_missing_baseline_signature_fails_the_run(): void
+    {
+        $this->scanner()->run('test', 'manual'); // creates baseline + .sig
+
+        unlink(storage_path('shield/integrity/test/baseline.ndjson.gz.sig'));
+
+        $run = $this->scanner()->run('test', 'manual');
+
+        $this->assertSame('failed', $run->status->name);
+    }
+
+    public function test_missing_last_run_artifact_does_not_duplicate_change_rows(): void
+    {
+        $this->scanner()->run('test', 'manual'); // writes baseline + last-run
+
+        // Remove only the previous-run reference (baseline survives).
+        @unlink(storage_path('shield/integrity/test/last-run.ndjson.gz'));
+        @unlink(storage_path('shield/integrity/test/last-run.ndjson.gz.sig'));
+
+        file_put_contents($this->src . '/app/New.php', '<?php // new');
+
+        $run = $this->scanner()->run('test', 'manual');
+
+        // Without a last-run, delta == drift; the change must be recorded once, not twice.
+        $this->assertSame(1, IntegrityChange::where('integrity_run_id', $run->id)
+            ->where('path', 'app/New.php')
+            ->count());
     }
 
     private function cleanArtifacts(): void

--- a/tests/Feature/Integrity/IntegrityScannerTest.php
+++ b/tests/Feature/Integrity/IntegrityScannerTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace OzanKurt\Shield\Tests\Feature\Integrity;
+
+use Illuminate\Support\Facades\Event;
+use OzanKurt\Shield\Events\IntegrityScanCompletedEvent;
+use OzanKurt\Shield\Models\IntegrityBaseline;
+use OzanKurt\Shield\Models\IntegrityChange;
+use OzanKurt\Shield\Services\Integrity\IntegrityScanner;
+use OzanKurt\Shield\Tests\TestCase;
+
+class IntegrityScannerTest extends TestCase
+{
+    private string $src;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->src = sys_get_temp_dir() . '/shield_scan_src_' . uniqid();
+        @mkdir($this->src . '/app', 0777, true);
+        @mkdir($this->src . '/public/cache', 0777, true);
+        file_put_contents($this->src . '/app/Service.php', '<?php // v1');
+        file_put_contents($this->src . '/readme.md', 'hello world');
+
+        config([
+            'shield.integrity.baseline.hmac_key' => 'test-key',
+            'shield.integrity.disks.test' => [
+                'roots' => [$this->src],
+                'key_base' => $this->src,
+                'include' => ['**/*'],
+                'exclude' => [],
+                'follow_symlinks' => false,
+                'max_file_size' => 50 * 1024 * 1024,
+            ],
+        ]);
+
+        $this->cleanArtifacts();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTree($this->src);
+        $this->cleanArtifacts();
+        parent::tearDown();
+    }
+
+    private function scanner(): IntegrityScanner
+    {
+        return new IntegrityScanner();
+    }
+
+    public function test_first_run_establishes_provisional_unsigned_baseline(): void
+    {
+        $run = $this->scanner()->run('test', 'manual');
+
+        $this->assertSame('baseline_established', $run->status->name);
+        $this->assertGreaterThan(0, $run->files_total);
+        $this->assertFileExists(storage_path('shield/integrity/test/baseline.ndjson.gz'));
+
+        $baseline = IntegrityBaseline::where('disk', 'test')->first();
+        $this->assertNotNull($baseline);
+        $this->assertFalse($baseline->signed); // provisional, not yet trusted
+    }
+
+    public function test_second_run_detects_new_and_modified_files_and_fires_event(): void
+    {
+        Event::fake([IntegrityScanCompletedEvent::class]);
+
+        $this->scanner()->run('test', 'manual'); // establish baseline
+
+        file_put_contents($this->src . '/app/Service.php', '<?php // v2 changed and longer');
+        file_put_contents($this->src . '/app/New.php', '<?php // brand new file');
+
+        $run = $this->scanner()->run('test', 'scheduled');
+
+        $this->assertSame('completed', $run->status->name);
+        $this->assertSame(1, $run->count_new);
+        $this->assertSame(1, $run->count_modified);
+
+        $this->assertTrue(
+            IntegrityChange::where('integrity_run_id', $run->id)->where('path', 'app/New.php')->exists()
+        );
+
+        Event::assertDispatched(IntegrityScanCompletedEvent::class);
+    }
+
+    public function test_new_php_under_public_is_critical(): void
+    {
+        $this->scanner()->run('test', 'manual'); // baseline
+
+        file_put_contents($this->src . '/public/cache/footer.php', '<?php /* dropped webshell */');
+
+        $run = $this->scanner()->run('test', 'manual');
+
+        $this->assertSame('critical', $run->severity->name);
+
+        $change = IntegrityChange::where('integrity_run_id', $run->id)
+            ->where('path', 'public/cache/footer.php')
+            ->first();
+        $this->assertNotNull($change);
+        $this->assertSame('critical', $change->severity->name);
+    }
+
+    public function test_tampered_baseline_is_flagged_and_not_reblessed(): void
+    {
+        $this->scanner()->run('test', 'manual'); // baseline + signature
+
+        file_put_contents(storage_path('shield/integrity/test/baseline.ndjson.gz.sig'), 'deadbeef');
+
+        $run = $this->scanner()->run('test', 'manual');
+
+        $this->assertSame('tamper_suspected', $run->status->name);
+        $this->assertSame('critical', $run->severity->name);
+    }
+
+    public function test_bless_signs_the_baseline(): void
+    {
+        $this->scanner()->run('test', 'manual'); // provisional, unsigned
+        $baseline = $this->scanner()->bless('test');
+
+        $this->assertTrue($baseline->signed);
+        $this->assertSame('test', $baseline->disk);
+        $this->assertSame(1, IntegrityBaseline::where('disk', 'test')->count()); // old row replaced
+    }
+
+    private function cleanArtifacts(): void
+    {
+        $this->deleteTree(storage_path('shield/integrity/test'));
+    }
+
+    private function deleteTree(string $dir): void
+    {
+        if (! is_dir($dir)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($items as $item) {
+            if ($item->isLink() || $item->isFile()) {
+                @unlink($item->getPathname());
+            } else {
+                @rmdir($item->getPathname());
+            }
+        }
+        @rmdir($dir);
+    }
+}

--- a/tests/Feature/NotificationTest.php
+++ b/tests/Feature/NotificationTest.php
@@ -2,21 +2,68 @@
 
 namespace OzanKurt\Shield\Tests\Feature;
 
+use Illuminate\Support\Facades\Http;
+use OzanKurt\Shield\Models\Log;
+use OzanKurt\Shield\Notifications\AttackDetectedNotification;
+use OzanKurt\Shield\Notifications\Notifiable;
 use OzanKurt\Shield\Tests\TestCase;
 
 class NotificationTest extends TestCase
 {
+    private function makeLog(): Log
+    {
+        return new Log([
+            'middleware' => 'sqli',
+            'ip' => '203.0.113.77',
+            'url' => 'https://example.com/?q=1%20OR%201=1',
+            'user_id' => 0,
+        ]);
+    }
+
     /**
      * @test
      */
-    public function can_send_notification_to_discord()
+    public function it_delivers_an_attack_notification_to_the_discord_webhook(): void
     {
-        $this->markTestSkipped(
-            'Legacy test — to be rewritten in audit log expansion milestone. ' .
-            'The old Helper trait (OzanKurt\\Shield\\Traits\\Helper) no longer exists; ' .
-            'the trait moved to OzanKurt\\Shield\\Helpers\\Helper and no longer exposes ' .
-            'a log() helper. AttackDetected was renamed to AttackDetectedNotification. ' .
-            'Full notification integration tests will be added in the beta.2 notification milestone.'
-        );
+        config([
+            'shield.notifications.attack_detected.channels' => ['discord'],
+            'shield.notification_channels.discord.enabled' => true,
+            'shield.notification_channels.discord.webhook_url' => 'https://discord.com/api/webhooks/123/token',
+        ]);
+
+        Http::fake([
+            'discord.com/*' => Http::response('', 204),
+        ]);
+
+        // notifyNow drives the full via() -> DiscordChannel -> DiscordMessage::toArray() -> Http path
+        // synchronously, regardless of the ShouldQueue contract.
+        (new Notifiable)->notifyNow(new AttackDetectedNotification($this->makeLog()));
+
+        Http::assertSent(function ($request) {
+            $payload = $request->data();
+
+            return str_contains($request->url(), 'discord.com/api/webhooks/123/token')
+                && isset($payload['embeds'][0])
+                && in_array('203.0.113.77', array_column($payload['embeds'][0]['fields'], 'value'), true);
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function it_sends_nothing_when_every_channel_is_disabled(): void
+    {
+        config([
+            'shield.notifications.attack_detected.channels' => ['mail', 'slack', 'discord'],
+            'shield.notification_channels.mail.enabled' => false,
+            'shield.notification_channels.slack.enabled' => false,
+            'shield.notification_channels.discord.enabled' => false,
+        ]);
+
+        Http::fake();
+
+        (new Notifiable)->notifyNow(new AttackDetectedNotification($this->makeLog()));
+
+        Http::assertNothingSent();
     }
 }

--- a/tests/Feature/Premium/CentralClientTest.php
+++ b/tests/Feature/Premium/CentralClientTest.php
@@ -27,7 +27,7 @@ class CentralClientTest extends TestCase
             private bool $hasKey;
             public function __construct(bool $hasKey)
             {
-                // Skip parent constructor — we don't need a cache repo.
+                // Skip parent constructor, we don't need a cache repo.
                 $this->hasKey = $hasKey;
             }
             public function hasKey(): bool

--- a/tests/Feature/Premium/ForwardAuditToCentralJobTest.php
+++ b/tests/Feature/Premium/ForwardAuditToCentralJobTest.php
@@ -68,7 +68,7 @@ class ForwardAuditToCentralJobTest extends TestCase
 
         $job->handle($this->makeClient());
 
-        $this->assertTrue(true); // 4xx is permanent — no exception thrown
+        $this->assertTrue(true); // 4xx is permanent, no exception thrown
     }
 
     public function testHandleWithFiveXxPushEventThrowsToTriggerRetry(): void
@@ -116,7 +116,7 @@ class ForwardAuditToCentralJobTest extends TestCase
 
     public function testFailedUpdatesOnlyLatestDeliveryForAuditLogId(): void
     {
-        // Seed multiple WebhookDelivery rows for the same audit_log_id —
+        // Seed multiple WebhookDelivery rows for the same audit_log_id -
         // simulating retries that each opened a fresh "pending" row.
         // The previous bug rewrote ALL rows; failed() must only touch the
         // most-recent one so per-attempt history is preserved.

--- a/tests/Feature/Premium/WebhookDeliveryTest.php
+++ b/tests/Feature/Premium/WebhookDeliveryTest.php
@@ -45,7 +45,7 @@ class WebhookDeliveryTest extends TestCase
 
         $delivery->refresh();
         $this->assertGreaterThan(0, $delivery->duration_ms);
-        // Must be positive (the abs() fix) — should be roughly 5000 (±tolerance for test exec time)
+        // Must be positive (the abs() fix), should be roughly 5000 (±tolerance for test exec time)
         $this->assertGreaterThanOrEqual(4900, $delivery->duration_ms);
     }
 

--- a/tests/Feature/Premium/WebhookSignerTest.php
+++ b/tests/Feature/Premium/WebhookSignerTest.php
@@ -103,7 +103,7 @@ class WebhookSignerTest extends TestCase
         ]);
         $sigWithBoth = (new WebhookSigner())->sign($body);
 
-        // Sign with only the webhook secret — must produce same signature
+        // Sign with only the webhook secret, must produce same signature
         // bytes for the same ts+nonce; since those vary, instead compare
         // by deriving from headers + the EXPECTED secret manually.
         $ts = $sigWithBoth['X-Shield-Timestamp'];

--- a/tests/Unit/Concerns/HasAuditLogTest.php
+++ b/tests/Unit/Concerns/HasAuditLogTest.php
@@ -8,7 +8,7 @@ use OzanKurt\Shield\Models\AuditLog;
 use OzanKurt\Shield\Models\Lookups\AuditLogKind;
 use OzanKurt\Shield\Tests\TestCase;
 
-// Named stub model — avoids the anonymous-class basename weirdness in tests
+// Named stub model, avoids the anonymous-class basename weirdness in tests
 class AuditableWidget extends Model
 {
     use HasAuditLog;

--- a/tests/Unit/Concerns/HasUserstampsTest.php
+++ b/tests/Unit/Concerns/HasUserstampsTest.php
@@ -190,7 +190,7 @@ class HasUserstampsTest extends TestCase
         // deleted_by_id should be user B (2)
         $this->assertSame(2, $record->deleted_by_id);
 
-        // updated_by_id must still be user A (1) — no cascade through updating event
+        // updated_by_id must still be user A (1), no cascade through updating event
         $fresh = $model->newQuery()->withTrashed()->find($inserted);
         $this->assertSame(1, $fresh->updated_by_id);
         $this->assertSame(2, $fresh->deleted_by_id);

--- a/tests/Unit/Notifications/AttackDetectedNotificationTest.php
+++ b/tests/Unit/Notifications/AttackDetectedNotificationTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace OzanKurt\Shield\Tests\Unit\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use OzanKurt\Shield\Models\Log;
+use OzanKurt\Shield\Notifications\AttackDetectedNotification;
+use OzanKurt\Shield\Notifications\Channels\Discord\DiscordChannel;
+use OzanKurt\Shield\Notifications\Channels\Discord\DiscordMessage;
+use OzanKurt\Shield\Notifications\Notifiable;
+use OzanKurt\Shield\Tests\TestCase;
+
+class AttackDetectedNotificationTest extends TestCase
+{
+    private function makeLog(): Log
+    {
+        return new Log([
+            'middleware' => 'sqli',
+            'ip' => '203.0.113.5',
+            'url' => 'https://example.com/login?id=1%20OR%201=1',
+            'user_id' => 7,
+        ]);
+    }
+
+    public function test_via_returns_only_enabled_channels_mapped_to_classes(): void
+    {
+        config([
+            'shield.notifications.attack_detected.channels' => ['mail', 'slack', 'discord'],
+            'shield.notification_channels.mail.enabled' => false,
+            'shield.notification_channels.slack.enabled' => true,
+            'shield.notification_channels.discord.enabled' => true,
+        ]);
+
+        $channels = (new AttackDetectedNotification($this->makeLog()))->via(new Notifiable);
+
+        // mail excluded (disabled); discord mapped to its custom channel class.
+        $this->assertSame(['slack', DiscordChannel::class], $channels);
+    }
+
+    public function test_via_returns_empty_when_no_channel_enabled(): void
+    {
+        config([
+            'shield.notifications.attack_detected.channels' => ['mail', 'slack', 'discord'],
+            'shield.notification_channels.mail.enabled' => false,
+            'shield.notification_channels.slack.enabled' => false,
+            'shield.notification_channels.discord.enabled' => false,
+        ]);
+
+        $this->assertSame([], (new AttackDetectedNotification($this->makeLog()))->via(new Notifiable));
+    }
+
+    public function test_via_queues_map_channel_classes_to_configured_queue(): void
+    {
+        config([
+            'shield.notifications.attack_detected.channels' => ['slack', 'discord'],
+            'shield.notification_channels.slack.queue' => 'alerts',
+            'shield.notification_channels.discord.queue' => 'discord-q',
+        ]);
+
+        $queues = (new AttackDetectedNotification($this->makeLog()))->viaQueues();
+
+        $this->assertSame('alerts', $queues['slack']);
+        $this->assertSame('discord-q', $queues[DiscordChannel::class]);
+    }
+
+    public function test_to_mail_builds_a_mail_message(): void
+    {
+        $mail = (new AttackDetectedNotification($this->makeLog()))->toMail(new Notifiable);
+
+        $this->assertInstanceOf(MailMessage::class, $mail);
+        $this->assertNotEmpty($mail->subject);
+    }
+
+    public function test_to_slack_builds_a_slack_message(): void
+    {
+        $slack = (new AttackDetectedNotification($this->makeLog()))->toSlack(new Notifiable);
+
+        $this->assertInstanceOf(SlackMessage::class, $slack);
+    }
+
+    public function test_to_discord_builds_a_discord_message(): void
+    {
+        $discord = (new AttackDetectedNotification($this->makeLog()))->toDiscord();
+
+        $this->assertInstanceOf(DiscordMessage::class, $discord);
+
+        // Fields carry the log data, proving it read real properties (not $this->notifications).
+        $embed = $discord->toArray()['embeds'][0];
+        $names = array_column($embed['fields'], 'value');
+        $this->assertContains('203.0.113.5', $names);
+    }
+}

--- a/tests/Unit/Notifications/Channels/Discord/DiscordMessageTest.php
+++ b/tests/Unit/Notifications/Channels/Discord/DiscordMessageTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace OzanKurt\Shield\Tests\Unit\Notifications\Channels\Discord;
+
+use OzanKurt\Shield\Notifications\Channels\Discord\DiscordMessage;
+use OzanKurt\Shield\Tests\TestCase;
+
+class DiscordMessageTest extends TestCase
+{
+    public function test_to_array_is_safe_without_a_color_method(): void
+    {
+        $embed = (new DiscordMessage)->title('Test')->toArray()['embeds'][0];
+
+        // Default gray color, not hexdec(null).
+        $this->assertSame(hexdec(DiscordMessage::COLOR_DEFAULT), $embed['color']);
+    }
+
+    public function test_footer_icon_uses_the_footer_url(): void
+    {
+        $embed = (new DiscordMessage)
+            ->footer('Shield', 'https://example.com/icon.png')
+            ->toArray()['embeds'][0];
+
+        $this->assertSame('https://example.com/icon.png', $embed['footer']['icon_url']);
+    }
+
+    public function test_timestamp_defaults_to_an_iso8601_string(): void
+    {
+        $embed = (new DiscordMessage)->title('Test')->toArray()['embeds'][0];
+
+        $this->assertIsString($embed['timestamp']);
+    }
+}

--- a/tests/Unit/Notifications/FailedLoginNotificationTest.php
+++ b/tests/Unit/Notifications/FailedLoginNotificationTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace OzanKurt\Shield\Tests\Unit\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use OzanKurt\Shield\Models\AuthLog;
+use OzanKurt\Shield\Notifications\Channels\Discord\DiscordChannel;
+use OzanKurt\Shield\Notifications\Channels\Discord\DiscordMessage;
+use OzanKurt\Shield\Notifications\FailedLoginNotification;
+use OzanKurt\Shield\Notifications\Notifiable;
+use OzanKurt\Shield\Tests\TestCase;
+
+class FailedLoginNotificationTest extends TestCase
+{
+    private function makeAuthLog(): AuthLog
+    {
+        return new AuthLog([
+            'email' => 'attacker@example.com',
+            'ip' => '198.51.100.9',
+            'user_id' => null,
+            'is_successful' => false,
+        ]);
+    }
+
+    public function test_via_reads_the_failed_login_event_and_returns_enabled_channels(): void
+    {
+        config([
+            'shield.notifications.failed_login.channels' => ['mail', 'slack', 'discord'],
+            'shield.notification_channels.mail.enabled' => true,
+            'shield.notification_channels.slack.enabled' => false,
+            'shield.notification_channels.discord.enabled' => true,
+        ]);
+
+        $channels = (new FailedLoginNotification($this->makeAuthLog()))->via(new Notifiable);
+
+        // slack excluded (disabled); discord mapped to its channel class.
+        $this->assertSame(['mail', DiscordChannel::class], $channels);
+    }
+
+    public function test_via_queues_map_channels_to_configured_queue(): void
+    {
+        config([
+            'shield.notifications.failed_login.channels' => ['mail', 'discord'],
+            'shield.notification_channels.mail.queue' => 'mail-q',
+            'shield.notification_channels.discord.queue' => 'discord-q',
+        ]);
+
+        $queues = (new FailedLoginNotification($this->makeAuthLog()))->viaQueues();
+
+        $this->assertSame('mail-q', $queues['mail']);
+        $this->assertSame('discord-q', $queues[DiscordChannel::class]);
+    }
+
+    public function test_to_mail_builds_a_mail_message(): void
+    {
+        $mail = (new FailedLoginNotification($this->makeAuthLog()))->toMail(new Notifiable);
+
+        $this->assertInstanceOf(MailMessage::class, $mail);
+        $this->assertNotEmpty($mail->subject);
+    }
+
+    public function test_to_slack_builds_a_slack_message(): void
+    {
+        $slack = (new FailedLoginNotification($this->makeAuthLog()))->toSlack(new Notifiable);
+
+        $this->assertInstanceOf(SlackMessage::class, $slack);
+    }
+
+    public function test_to_discord_builds_a_discord_message_with_authlog_data(): void
+    {
+        $discord = (new FailedLoginNotification($this->makeAuthLog()))->toDiscord();
+
+        $this->assertInstanceOf(DiscordMessage::class, $discord);
+
+        $embed = $discord->toArray()['embeds'][0];
+        $values = array_column($embed['fields'], 'value');
+        $this->assertContains('198.51.100.9', $values);
+        $this->assertContains('attacker@example.com', $values);
+    }
+}

--- a/tests/Unit/Notifications/NotifiableTest.php
+++ b/tests/Unit/Notifications/NotifiableTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace OzanKurt\Shield\Tests\Unit\Notifications;
+
+use OzanKurt\Shield\Notifications\Notifiable;
+use OzanKurt\Shield\Tests\TestCase;
+
+class NotifiableTest extends TestCase
+{
+    public function test_routes_resolve_from_notification_channels_layer(): void
+    {
+        config([
+            'shield.notification_channels.mail.to' => 'ops@example.com',
+            'shield.notification_channels.slack.to' => 'https://hooks.slack.com/services/T/B/x',
+            'shield.notification_channels.discord.webhook_url' => 'https://discord.com/api/webhooks/1/abc',
+        ]);
+
+        $notifiable = new Notifiable();
+
+        $this->assertSame('ops@example.com', $notifiable->routeNotificationForMail());
+        $this->assertSame('https://hooks.slack.com/services/T/B/x', $notifiable->routeNotificationForSlack());
+        $this->assertSame('https://discord.com/api/webhooks/1/abc', $notifiable->routeNotificationForDiscord());
+    }
+}

--- a/tests/Unit/Notifications/SecurityReportNotificationTest.php
+++ b/tests/Unit/Notifications/SecurityReportNotificationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace OzanKurt\Shield\Tests\Unit\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use Illuminate\Support\Carbon;
+use OzanKurt\Shield\Notifications\Channels\Discord\DiscordMessage;
+use OzanKurt\Shield\Notifications\Notifiable;
+use OzanKurt\Shield\Notifications\SecurityReportNotification;
+use OzanKurt\Shield\Tests\TestCase;
+
+class SecurityReportNotificationTest extends TestCase
+{
+    private function makeNotification(): SecurityReportNotification
+    {
+        return new SecurityReportNotification(
+            [['/var/www/app/config/app.php', 1718000000]],
+            Carbon::parse('2026-06-01'),
+            Carbon::parse('2026-06-08'),
+        );
+    }
+
+    public function test_via_returns_enabled_channels_for_the_security_report_event(): void
+    {
+        config([
+            'shield.notifications.security_report.channels' => ['mail'],
+            'shield.notification_channels.mail.enabled' => true,
+        ]);
+
+        $this->assertSame(['mail'], $this->makeNotification()->via(new Notifiable));
+    }
+
+    public function test_via_returns_empty_when_the_channel_is_disabled(): void
+    {
+        config([
+            'shield.notifications.security_report.channels' => ['mail'],
+            'shield.notification_channels.mail.enabled' => false,
+        ]);
+
+        $this->assertSame([], $this->makeNotification()->via(new Notifiable));
+    }
+
+    public function test_via_queues_map_channels_to_configured_queue(): void
+    {
+        config([
+            'shield.notifications.security_report.channels' => ['mail'],
+            'shield.notification_channels.mail.queue' => 'reports',
+        ]);
+
+        $this->assertSame('reports', $this->makeNotification()->viaQueues()['mail']);
+    }
+
+    public function test_to_mail_builds_a_mail_message(): void
+    {
+        $mail = $this->makeNotification()->toMail(new Notifiable);
+
+        $this->assertInstanceOf(MailMessage::class, $mail);
+        $this->assertNotEmpty($mail->subject);
+    }
+
+    public function test_to_slack_builds_a_slack_message_without_undefined_properties(): void
+    {
+        $slack = $this->makeNotification()->toSlack(new Notifiable);
+
+        $this->assertInstanceOf(SlackMessage::class, $slack);
+    }
+
+    public function test_to_discord_builds_a_discord_message_without_undefined_properties(): void
+    {
+        $discord = $this->makeNotification()->toDiscord();
+
+        $this->assertInstanceOf(DiscordMessage::class, $discord);
+    }
+}

--- a/tests/Unit/Notifications/SlackChannelAvailableTest.php
+++ b/tests/Unit/Notifications/SlackChannelAvailableTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace OzanKurt\Shield\Tests\Unit\Notifications;
+
+use OzanKurt\Shield\Tests\TestCase;
+
+class SlackChannelAvailableTest extends TestCase
+{
+    public function test_legacy_slack_message_class_is_available(): void
+    {
+        $this->assertTrue(
+            class_exists(\Illuminate\Notifications\Messages\SlackMessage::class),
+            'laravel/slack-notification-channel must be installed so the legacy webhook SlackMessage exists.'
+        );
+    }
+}

--- a/tests/Unit/Notifications/SuccessfulLoginNotificationTest.php
+++ b/tests/Unit/Notifications/SuccessfulLoginNotificationTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace OzanKurt\Shield\Tests\Unit\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Messages\SlackMessage;
+use OzanKurt\Shield\Models\AuthLog;
+use OzanKurt\Shield\Notifications\Channels\Discord\DiscordChannel;
+use OzanKurt\Shield\Notifications\Channels\Discord\DiscordMessage;
+use OzanKurt\Shield\Notifications\Notifiable;
+use OzanKurt\Shield\Notifications\SuccessfulLoginNotification;
+use OzanKurt\Shield\Tests\TestCase;
+
+class SuccessfulLoginNotificationTest extends TestCase
+{
+    private function makeAuthLog(): AuthLog
+    {
+        return new AuthLog([
+            'email' => 'user@example.com',
+            'ip' => '192.0.2.20',
+            'user_id' => 42,
+            'is_successful' => true,
+        ]);
+    }
+
+    public function test_via_reads_the_successful_login_event_and_returns_enabled_channels(): void
+    {
+        config([
+            'shield.notifications.successful_login.channels' => ['mail', 'slack', 'discord'],
+            'shield.notification_channels.mail.enabled' => false,
+            'shield.notification_channels.slack.enabled' => true,
+            'shield.notification_channels.discord.enabled' => true,
+        ]);
+
+        $channels = (new SuccessfulLoginNotification($this->makeAuthLog()))->via(new Notifiable);
+
+        $this->assertSame(['slack', DiscordChannel::class], $channels);
+    }
+
+    public function test_via_queues_map_channels_to_configured_queue(): void
+    {
+        config([
+            'shield.notifications.successful_login.channels' => ['slack', 'discord'],
+            'shield.notification_channels.slack.queue' => 'slack-q',
+            'shield.notification_channels.discord.queue' => 'discord-q',
+        ]);
+
+        $queues = (new SuccessfulLoginNotification($this->makeAuthLog()))->viaQueues();
+
+        $this->assertSame('slack-q', $queues['slack']);
+        $this->assertSame('discord-q', $queues[DiscordChannel::class]);
+    }
+
+    public function test_to_mail_builds_a_mail_message(): void
+    {
+        $mail = (new SuccessfulLoginNotification($this->makeAuthLog()))->toMail(new Notifiable);
+
+        $this->assertInstanceOf(MailMessage::class, $mail);
+        $this->assertNotEmpty($mail->subject);
+    }
+
+    public function test_to_slack_builds_a_slack_message(): void
+    {
+        $slack = (new SuccessfulLoginNotification($this->makeAuthLog()))->toSlack(new Notifiable);
+
+        $this->assertInstanceOf(SlackMessage::class, $slack);
+    }
+
+    public function test_to_discord_builds_a_discord_message_with_authlog_data(): void
+    {
+        $discord = (new SuccessfulLoginNotification($this->makeAuthLog()))->toDiscord();
+
+        $this->assertInstanceOf(DiscordMessage::class, $discord);
+
+        $embed = $discord->toArray()['embeds'][0];
+        $values = array_column($embed['fields'], 'value');
+        $this->assertContains('192.0.2.20', $values);
+        $this->assertContains(42, $values);
+    }
+}

--- a/tests/Unit/Services/Integrity/BaselineTest.php
+++ b/tests/Unit/Services/Integrity/BaselineTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace OzanKurt\Shield\Tests\Unit\Services\Integrity;
+
+use InvalidArgumentException;
+use OzanKurt\Shield\Services\Integrity\Baseline;
+use OzanKurt\Shield\Services\Integrity\BaselineCorruptException;
+use OzanKurt\Shield\Services\Integrity\BaselineTamperException;
+use OzanKurt\Shield\Tests\TestCase;
+
+class BaselineTest extends TestCase
+{
+    private string $dir;
+    private string $path;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->dir = sys_get_temp_dir() . '/shield_baseline_' . uniqid();
+        $this->path = $this->dir . '/baseline.ndjson.gz';
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->dir . '/*') ?: [] as $f) {
+            @unlink($f);
+        }
+        @rmdir($this->dir);
+        parent::tearDown();
+    }
+
+    private function sampleManifest(): array
+    {
+        return [
+            'app/Foo.php' => ['sha256' => str_repeat('a', 64), 'size' => 10, 'mtime' => 111, 'kind' => 'hashed', 'target' => null],
+            'public/cache/footer.php' => ['sha256' => str_repeat('b', 64), 'size' => 20, 'mtime' => 222, 'kind' => 'hashed', 'target' => null],
+            'notes.txt' => ['sha256' => null, 'size' => 99, 'mtime' => 333, 'kind' => 'size_only', 'target' => null],
+        ];
+    }
+
+    public function test_write_then_read_round_trips_manifest_and_meta(): void
+    {
+        $baseline = new Baseline('secret-key');
+        $manifest = $this->sampleManifest();
+        $meta = ['disk' => 'app', 'scope_fingerprint' => 'fp123', 'root_hash' => 'rh456', 'files_total' => 3];
+
+        $baseline->write($this->path, $manifest, $meta);
+        $read = $baseline->read($this->path);
+
+        // Baseline canonically sorts by key; compare against the sorted form.
+        ksort($manifest);
+        $this->assertSame($manifest, $read['manifest']);
+        $this->assertSame($meta, $read['meta']);
+    }
+
+    public function test_missing_artifact_reads_as_null(): void
+    {
+        $baseline = new Baseline('secret-key');
+
+        $this->assertNull($baseline->read($this->path));
+    }
+
+    public function test_write_is_atomic_and_leaves_no_tmp_files(): void
+    {
+        (new Baseline('secret-key'))->write($this->path, $this->sampleManifest(), ['disk' => 'app']);
+
+        $this->assertFileExists($this->path);
+        $this->assertFileExists($this->path . '.sig');
+        $this->assertFileDoesNotExist($this->path . '.tmp');
+        $this->assertFileDoesNotExist($this->path . '.sig.tmp');
+    }
+
+    public function test_tampered_signature_throws_tamper_exception(): void
+    {
+        $baseline = new Baseline('secret-key');
+        $baseline->write($this->path, $this->sampleManifest(), ['disk' => 'app']);
+
+        // Rewrite the signature: artifact still decompresses and parses, but the
+        // HMAC will not verify -> security signal, not corruption.
+        file_put_contents($this->path . '.sig', 'deadbeef');
+
+        $this->expectException(BaselineTamperException::class);
+        $baseline->read($this->path);
+    }
+
+    public function test_a_different_key_fails_verification_as_tamper(): void
+    {
+        (new Baseline('key-one'))->write($this->path, $this->sampleManifest(), ['disk' => 'app']);
+
+        $this->expectException(BaselineTamperException::class);
+        (new Baseline('key-two'))->read($this->path);
+    }
+
+    public function test_corrupt_gzip_throws_corrupt_exception(): void
+    {
+        $baseline = new Baseline('secret-key');
+        $baseline->write($this->path, $this->sampleManifest(), ['disk' => 'app']);
+
+        file_put_contents($this->path, 'this is not gzip');
+
+        $this->expectException(BaselineCorruptException::class);
+        $baseline->read($this->path);
+    }
+
+    public function test_empty_key_is_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Baseline('');
+    }
+
+    public function test_placeholder_key_is_rejected(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        new Baseline(Baseline::PLACEHOLDER_KEY);
+    }
+}

--- a/tests/Unit/Services/Integrity/ManifestTest.php
+++ b/tests/Unit/Services/Integrity/ManifestTest.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace OzanKurt\Shield\Tests\Unit\Services\Integrity;
+
+use OzanKurt\Shield\Services\Integrity\Manifest;
+use OzanKurt\Shield\Services\Integrity\ManifestLimitException;
+use OzanKurt\Shield\Tests\TestCase;
+
+class ManifestTest extends TestCase
+{
+    private string $base;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->base = sys_get_temp_dir() . '/shield_manifest_' . uniqid();
+        @mkdir($this->base . '/app', 0777, true);
+        @mkdir($this->base . '/vendor', 0777, true);
+        @mkdir($this->base . '/storage/logs', 0777, true);
+
+        file_put_contents($this->base . '/app/Foo.php', "<?php echo 'hello world';");
+        file_put_contents($this->base . '/notes.txt', 'hello world long enough');
+        file_put_contents($this->base . '/tiny.txt', 'ab');
+        file_put_contents($this->base . '/vendor/lib.php', 'excluded');
+        file_put_contents($this->base . '/storage/logs/x.log', 'excluded');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteTree($this->base);
+        parent::tearDown();
+    }
+
+    private function manifest(array $overrides = []): Manifest
+    {
+        return new Manifest(array_merge([
+            'roots' => [$this->base],
+            'key_base' => $this->base,
+            'include' => ['**/*'],
+            'exclude' => ['vendor/**', 'storage/**'],
+            'follow_symlinks' => false,
+            'max_file_size' => 5, // small, so non-script files over 5 bytes go size_only
+        ], $overrides));
+    }
+
+    public function test_builds_classified_sorted_manifest_respecting_globs(): void
+    {
+        $m = $this->manifest()->build();
+
+        $this->assertArrayHasKey('app/Foo.php', $m);
+        $this->assertArrayHasKey('notes.txt', $m);
+        $this->assertArrayHasKey('tiny.txt', $m);
+        $this->assertArrayNotHasKey('vendor/lib.php', $m);          // excluded
+        $this->assertArrayNotHasKey('storage/logs/x.log', $m);      // excluded
+
+        // .php is always hashed even though it is over max_file_size.
+        $this->assertSame('hashed', $m['app/Foo.php']['kind']);
+        $this->assertSame(hash_file('sha256', $this->base . '/app/Foo.php'), $m['app/Foo.php']['sha256']);
+
+        // A large non-script file is recorded by size only.
+        $this->assertSame('size_only', $m['notes.txt']['kind']);
+        $this->assertNull($m['notes.txt']['sha256']);
+
+        // A small file is hashed.
+        $this->assertSame('hashed', $m['tiny.txt']['kind']);
+
+        // Sorted by key.
+        $this->assertSame(array_keys($m), array_values(array_keys($m)));
+        $sorted = array_keys($m);
+        $expected = $sorted;
+        sort($expected);
+        $this->assertSame($expected, $sorted);
+    }
+
+    public function test_diff_reports_new_modified_deleted(): void
+    {
+        $base = $this->manifest()->build();
+
+        // modify a hashed file, add a new one, delete one
+        file_put_contents($this->base . '/app/Foo.php', "<?php echo 'changed now';");
+        file_put_contents($this->base . '/tiny2.txt', 'cd');
+        unlink($this->base . '/tiny.txt');
+
+        $current = $this->manifest()->build();
+        $diff = Manifest::diff($base, $current);
+
+        $this->assertArrayHasKey('app/Foo.php', $diff['modified']);
+        $this->assertArrayHasKey('tiny2.txt', $diff['new']);
+        $this->assertArrayHasKey('tiny.txt', $diff['deleted']);
+    }
+
+    public function test_incremental_carries_prior_hash_when_size_and_mtime_match(): void
+    {
+        $first = $this->manifest()->build();
+
+        // Poison the prior hash; since the file is untouched (same size+mtime),
+        // build() must carry the prior hash forward instead of re-hashing.
+        $first['app/Foo.php']['sha256'] = 'POISONED';
+
+        $second = $this->manifest()->build($first);
+
+        $this->assertSame('POISONED', $second['app/Foo.php']['sha256']);
+    }
+
+    public function test_root_hash_is_stable_and_changes_with_content(): void
+    {
+        $a = $this->manifest()->build();
+        $h1 = Manifest::rootHash($a);
+        $h2 = Manifest::rootHash($this->manifest()->build());
+        $this->assertSame($h1, $h2);
+
+        file_put_contents($this->base . '/app/Foo.php', "<?php echo 'mutated';");
+        $h3 = Manifest::rootHash($this->manifest()->build());
+        $this->assertNotSame($h1, $h3);
+    }
+
+    public function test_hashes_view_returns_only_hashed_entries(): void
+    {
+        $hashes = Manifest::hashes($this->manifest()->build());
+
+        $this->assertArrayHasKey('app/Foo.php', $hashes);
+        $this->assertArrayHasKey('tiny.txt', $hashes);
+        $this->assertArrayNotHasKey('notes.txt', $hashes); // size_only, no hash
+    }
+
+    public function test_file_cap_aborts_with_limit_exception(): void
+    {
+        $this->expectException(ManifestLimitException::class);
+
+        $this->manifest(['max_files' => 1])->build();
+    }
+
+    public function test_symlink_recorded_without_following(): void
+    {
+        $linkOk = @symlink($this->base . '/app/Foo.php', $this->base . '/shortcut.php');
+        if ($linkOk === false || ! is_link($this->base . '/shortcut.php')) {
+            $this->markTestSkipped('Symlinks not supported in this environment.');
+        }
+
+        $m = $this->manifest()->build();
+
+        $this->assertArrayHasKey('shortcut.php', $m);
+        $this->assertSame('symlink', $m['shortcut.php']['kind']);
+        $this->assertNull($m['shortcut.php']['sha256']);
+    }
+
+    private function deleteTree(string $dir): void
+    {
+        if (! is_dir($dir)) {
+            return;
+        }
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($items as $item) {
+            if ($item->isLink() || $item->isFile()) {
+                @unlink($item->getPathname());
+            } else {
+                @rmdir($item->getPathname());
+            }
+        }
+        @rmdir($dir);
+    }
+}


### PR DESCRIPTION
Implements spec-005: a Wordfence-style **file integrity scan** that diffs the filesystem against an approved baseline and posts a grouped New / Modified / Deleted summary to mail, Slack, and Discord (the screenshot the request started from).

## What it does

```bash
php artisan shield:integrity         # first run: PROVISIONAL baseline (review it)
php artisan shield:integrity-bless   # approve the reviewed baseline
# later runs diff against it and notify on change
```

Plus a `/shield/integrity` dashboard (runs, changes, Run/Approve buttons).

## How it works

- `Manifest`: canonical-keyed file hasher with include/exclude globs, symlink handling, iteration caps, and an incremental size+mtime pre-filter (carry prior hash when unchanged).
- `Baseline`: signed, atomically written gzipped NDJSON artifact; distinguishes tamper (HMAC mismatch) from corruption.
- `IntegrityScanner`: per-disk lock, hybrid diff (per-run delta vs the previous run, drift vs the pinned known-good), severity scoring, run + change persistence, fires `IntegrityScanCompletedEvent`.
- Notification built from bounded queries + persisted counts (never hydrates the full change set), severity colour shared across channels, highest-severity paths surfaced first.

## Secure by default (verified in code)

- First run establishes a PROVISIONAL baseline; it is never auto-trusted.
- A tampered baseline is flagged `tamper_suspected` (critical) and is NOT rebuilt.
- Signing key is fail-closed (empty/placeholder rejected).
- A new `.php` under `public/` scores critical and is never truncated away.
- Security/operational events bypass zero-change suppression.
- Script extensions are always hashed regardless of `max_file_size`.

## Prerequisites included

Fixes the notification plumbing the card depends on: adds `laravel/slack-notification-channel`, corrects `Notifiable` config paths, fixes `DiscordMessage` serialization, and repairs the four pre-existing broken notifications.

## Testing

~35 new tests (Manifest, Baseline, data layer, scanner, notification, dashboard, commands). **Full suite 266 green** (1 symlink test skips on Windows). Hardened after a 10-agent adversarial review that refuted the false alarms and confirmed the security guarantees.

## Deferred (per spec, not blocking)

- Phase 2: remote disks (sftp/s3) + S3 ETag pre-filter, `composer.lock` dist-hash cross-check, premium real-time integrity.
- Phase 3: off-box Central attestation, two-person bless.
- Within Phase 1: chunked raw inserts (currently capped Eloquent), cache throttle (suppression covers the main case), the `shield:watch` DRY refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)